### PR TITLE
버튼 컴포넌트 타입 안전하게 스타일링

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -42,7 +42,7 @@ export const Button = ({
 }: ButtonProps) => {
   return (
     <button
-      className={css(styles.raw({ tone, variant, size }), baseStyles)}
+      className={styles({ tone, variant, size })}
       type={type}
       onClick={onClick}
       disabled={disabled}
@@ -53,29 +53,26 @@ export const Button = ({
   );
 };
 
-const baseStyles = {
-  appearance: "none",
-  margin: "0",
-  fontWeight: 500,
-  textAlign: "center",
-  textDecoration: "none",
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  width: ["auto", "100%"],
-  borderRadius: "10px",
-  cursor: "pointer",
-  transition: "0.2s",
-  lineHeight: "1",
-  outline: "0",
-  "&:disabled": {
-    opacity: 0.5,
-    cursor: "not-allowed",
-  },
-};
-
 const styles = cva({
   base: {
+    appearance: "none",
+    margin: "0",
+    fontWeight: 500,
+    textAlign: "center",
+    textDecoration: "none",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: ["auto", "100%"],
+    borderRadius: "10px",
+    cursor: "pointer",
+    transition: "0.2s",
+    lineHeight: "1",
+    outline: "0",
+    "&:disabled": {
+      opacity: 0.5,
+      cursor: "not-allowed",
+    },
     padding: "0.7rem 3rem",
   },
   variants: {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,5 +1,5 @@
 import React, { type HTMLAttributes } from "react";
-import { css, cva } from "../../../styled-system/css";
+import { cva } from "../../../styled-system/css";
 import type { Tone } from "../../tokens/colors";
 
 type ButtonVariant = "solid" | "outline";


### PR DESCRIPTION
버튼 컴포넌트가 타입 안전하게 스타일링되도록 수정하였습니다.

https://github.com/DaleStudy/daleui/pull/48#discussion_r1980572265 에 언급된 것처럼 일반 자바스크립트 객체를 사용해서 스타일링을 하면 Panda에서 제공하는 타입 안전성을 누리지 못하게 되며 버그 위험성이 커집니다.

기존에 작성된 테스트 모두 통과하며, Chromatic 테스트도 모두 통과함을 확인하였습니다.

![Shot 2025-03-12 at 18 05 23](https://github.com/user-attachments/assets/6cc62c38-0a57-47f4-a85d-7041dd1bf5ca)
