### PR TITLE
RadioGroup API 정의

### DIFF
--- a/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/src/components/RadioGroup/RadioGroup.test.tsx
@@ -4,7 +4,6 @@ test.todo("RadioGroup이 올바르게 자식 요소와 함께 렌더링됨");
 test.todo(
   "RadioGroup.Item이 RadioGroup.Root 외부에서 사용될 경우 에러가 발생함"
 );
-test.todo("최소 1개의 RadioGroup.Item이 필요함");
 test.todo("RadioGroup.Root의 name 속성이 올바르게 설정됨");
 
 test.todo("RadioGroup.Item의 value가 올바르게 동작함");

--- a/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/src/components/RadioGroup/RadioGroup.test.tsx
@@ -1,0 +1,29 @@
+import { test } from "vitest";
+
+test.todo("모든 옵션이 정상적으로 렌더링");
+
+test.todo("2개 미만 옵션 제공 시 에러 발생");
+
+test.todo("초기 defaultValue 값으로 선택됨");
+
+test.todo("옵션 선택 시 onValueChange 호출");
+
+test.todo("disabled 상태에서 모든 라디오 버튼 비활성화");
+
+test.todo("required 속성이 true일 때 필수 입력으로 표시");
+
+test.todo(
+  "orientation이 'horizontal'인 경우 라디오 아이템들이 가로 배열로 렌더링됨"
+);
+
+test.todo(
+  "orientation이 'vertical'인 경우 라디오 아이템들이 세로 배열로 렌더링됨"
+);
+
+test.todo("loop=true일 때 마지막 항목에서 첫 항목으로 이동 가능");
+
+test.todo("loop=false일 때 마지막 항목에서 이동 불가");
+
+test.todo("dir 속성이 미지정되면 기본값('ltr') 적용됨");
+
+test.todo("dir 속성에 따른 Label과 Indicator 정렬 방향이 적용됨");

--- a/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/src/components/RadioGroup/RadioGroup.test.tsx
@@ -1,33 +1,35 @@
 import { test } from "vitest";
 
-test.todo("options의 label과 value가 올바르게 렌더링됨");
+test.todo("RadioGroup이 올바르게 자식 요소와 함께 렌더링됨");
+test.todo(
+  "RadioGroup.Item이 RadioGroup.Root 외부에서 사용될 경우 에러가 발생함"
+);
+test.todo("최소 1개의 RadioGroup.Item이 필요함");
+test.todo("RadioGroup.Root의 name 속성이 올바르게 설정됨");
 
-test.todo("options의 disabled 속성이 올바르게 적용됨");
-
-test.todo("2개 미만 options 제공 시 에러가 발생함");
-
-test.todo("ReactNode 타입 label이 올바르게 렌더링됨");
-
-test.todo("name 속성이 모든 라디오 버튼에 올바르게 적용됨");
+test.todo("RadioGroup.Item의 value가 올바르게 동작함");
+test.todo("RadioGroup.Item의 disabled 속성이 올바르게 적용됨");
+test.todo("RadioGroup.Item 선택 시 onChange가 호출됨");
 
 test.todo("defaultValue가 제공될 때 해당 값이 선택됨");
-
 test.todo("defaultValue가 제공되지 않을 때 아무것도 선택되지 않음");
-
-test.todo("value가 제공될 때 해당 값이 선택됨 (제어 컴포넌트)");
-
 test.todo("value와 defaultValue가 모두 제공될 때 value가 우선시됨");
 
-test.todo("옵션 선택 시 onChange가 호출됨");
-
-test.todo("disabled가 true일 때 모든 라디오 버튼이 비활성화됨");
+test.todo("Root의 disabled가 true일 때 모든 RadioGroup.Item이 비활성화됨");
+test.todo("Item의 disabled가 true일 때 해당 아이템만 비활성화됨");
 
 test.todo("required가 true일 때 필수 입력으로 표시됨");
 
-test.todo("orientation이 'horizontal'일 때 라디오 버튼이 가로로 배열됨");
+test.todo("orientation이 'horizontal'일 때 RadioGroup.Item이 가로로 배열됨");
+test.todo("orientation이 'vertical'일 때 RadioGroup.Item이 세로로 배열됨");
 
-test.todo("orientation이 'vertical'일 때 라디오 버튼이 세로로 배열됨");
+test.todo("키보드 방향키로 RadioGroup.Item 간 이동이 가능함");
+test.todo("Tab 키로 RadioGroup에 초점을 맞출 수 있음");
 
-test.todo("키보드 방향키로 옵션 간 이동이 가능함");
+test.todo("폼 제출 시 선택된 RadioGroup 값이 올바르게 전송됨");
+test.todo("폼 리셋 시 RadioGroup이 defaultValue로 초기화됨");
+
+test.todo("RadioGroup.Item이 동적으로 추가/제거될 때 정상 작동함");
+test.todo("RadioGroup.Item 사이에 다른 컴포넌트가 있어도 올바르게 작동함");
 
 test.todo("tone prop에 따라 올바른 색상이 적용됨");

--- a/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/src/components/RadioGroup/RadioGroup.test.tsx
@@ -1,29 +1,31 @@
 import { test } from "vitest";
 
-test.todo("모든 옵션이 정상적으로 렌더링");
+test.todo("options의 label과 value가 올바르게 렌더링됨");
 
-test.todo("2개 미만 옵션 제공 시 에러 발생");
+test.todo("options의 disabled 속성이 올바르게 적용됨");
 
-test.todo("초기 defaultValue 값으로 선택됨");
+test.todo("2개 미만 options 제공 시 에러가 발생함");
 
-test.todo("옵션 선택 시 onValueChange 호출");
+test.todo("ReactNode 타입 label이 올바르게 렌더링됨");
 
-test.todo("disabled 상태에서 모든 라디오 버튼 비활성화");
+test.todo("name 속성이 모든 라디오 버튼에 올바르게 적용됨");
 
-test.todo("required 속성이 true일 때 필수 입력으로 표시");
+test.todo("defaultValue가 제공될 때 해당 값이 선택됨");
 
-test.todo(
-  "orientation이 'horizontal'인 경우 라디오 아이템들이 가로 배열로 렌더링됨"
-);
+test.todo("defaultValue가 제공되지 않을 때 아무것도 선택되지 않음");
 
-test.todo(
-  "orientation이 'vertical'인 경우 라디오 아이템들이 세로 배열로 렌더링됨"
-);
+test.todo("value가 제공될 때 해당 값이 선택됨 (제어 컴포넌트)");
 
-test.todo("loop=true일 때 마지막 항목에서 첫 항목으로 이동 가능");
+test.todo("value와 defaultValue가 모두 제공될 때 value가 우선시됨");
 
-test.todo("loop=false일 때 마지막 항목에서 이동 불가");
+test.todo("옵션 선택 시 onChange가 호출됨");
 
-test.todo("dir 속성이 미지정되면 기본값('ltr') 적용됨");
+test.todo("disabled가 true일 때 모든 라디오 버튼이 비활성화됨");
 
-test.todo("dir 속성에 따른 Label과 Indicator 정렬 방향이 적용됨");
+test.todo("required가 true일 때 필수 입력으로 표시됨");
+
+test.todo("orientation이 'horizontal'일 때 라디오 버튼이 가로로 배열됨");
+
+test.todo("orientation이 'vertical'일 때 라디오 버튼이 세로로 배열됨");
+
+test.todo("키보드 방향키로 옵션 간 이동이 가능함");

--- a/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/src/components/RadioGroup/RadioGroup.test.tsx
@@ -29,3 +29,5 @@ test.todo("orientation이 'horizontal'일 때 라디오 버튼이 가로로 배�
 test.todo("orientation이 'vertical'일 때 라디오 버튼이 세로로 배열됨");
 
 test.todo("키보드 방향키로 옵션 간 이동이 가능함");
+
+test.todo("tone prop에 따라 올바른 색상이 적용됨");

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import type { Tone } from "../../tokens/colors";
 
 export interface RadioGroupProps {
   /**
@@ -55,6 +56,9 @@ export interface RadioGroupProps {
    * @default undefined
    */
   orientation?: "horizontal" | "vertical";
+
+  /** 색조 */
+  tone?: Tone;
 }
 
 // eslint-disable-next-line no-empty-pattern

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -15,9 +15,8 @@ interface RadioGroupProps {
 
   /**
    * 라디오 그룹의 레이블: 라디오 그룹에 대한 설명을 제공합니다.
-   * @default undefined
    */
-  label?: string;
+  label: string;
 
   /**
    * 기본 선택값: 컴포넌트 초기 렌더링 시 선택될 값을 지정합니다.

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -62,7 +62,7 @@ export interface RadioGroupProps {
 }
 
 // eslint-disable-next-line no-empty-pattern
-export const RadioGroup = ({}: RadioGroupProps) => {
+export function RadioGroup({}: RadioGroupProps) {
   // TODO: RadioGroup 컴포넌트 구현
   return null;
-};
+}

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from "react";
 import type { Tone } from "../../tokens/colors";
 
-interface RadioGroupRootProps {
+interface RadioGroupProps {
   /**
    * RadioGroup의 자식 요소들입니다.
    * RadioGroup.Item 컴포넌트를 포함해야 합니다.
@@ -12,6 +12,12 @@ interface RadioGroupRootProps {
    * 폼 입력 이름: 동일한 그룹의 라디오 버튼들이 공유하는 이름을 지정합니다.
    */
   name: string;
+
+  /**
+   * 라디오 그룹의 레이블: 라디오 그룹에 대한 설명을 제공합니다.
+   * @default undefined
+   */
+  label?: string;
 
   /**
    * 기본 선택값: 컴포넌트 초기 렌더링 시 선택될 값을 지정합니다.
@@ -58,13 +64,13 @@ interface RadioGroupRootProps {
  * RadioGroup의 루트 컴포넌트입니다.
  * 라디오 버튼 그룹을 정의하고 상태를.관리합니다.
  */
-// eslint-disable-next-line react-refresh/only-export-components, no-empty-pattern
-function Root({}: RadioGroupRootProps) {
+// eslint-disable-next-line no-empty-pattern
+export function RadioGroup({}: RadioGroupProps) {
   // TODO: 구현
   return null;
 }
 
-interface RadioGroupItemProps {
+interface RadioProps {
   /**
    * 라디오 버튼의 값입니다.
    */
@@ -86,13 +92,8 @@ interface RadioGroupItemProps {
  * 라디오 그룹의 개별 항목입니다.
  * 선택 가능한 단일 라디오 버튼을 나타냅니다.
  */
-// eslint-disable-next-line react-refresh/only-export-components, no-empty-pattern
-function Item({}: RadioGroupItemProps) {
+// eslint-disable-next-line no-empty-pattern
+export function Radio({}: RadioProps) {
   // TODO: 구현
   return null;
 }
-
-export const RadioGroup = {
-  Root,
-  Item,
-};

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -1,0 +1,68 @@
+export interface RadioGroupProps {
+  /**
+   * 라디오 옵션 배열: 각 옵션은 label(표시 텍스트)과 value(실제 값)를 포함합니다.
+   */
+  options: { label: string; value: string }[];
+
+  /**
+   * 기본 선택값: 컴포넌트 초기 렌더링 시 선택될 값을 지정합니다.
+   * @default undefined
+   */
+  defaultValue?: string;
+
+  /**
+   * 현재 선택된 값: 외부에서 값을 직접 관리할 때 사용합니다.
+   * @default undefined
+   */
+  value?: string;
+
+  /**
+   * 값 변경 핸들러: 사용자가 선택을 변경할 때 호출되는 콜백 함수입니다.
+   * @default undefined
+   */
+  onValueChange?: (value: string) => void;
+
+  /**
+   * 비활성화 여부: true이면 모든 라디오 버튼이 비활성화되어 상호작용을 차단합니다.
+   * @default false
+   */
+  disabled?: boolean;
+
+  /**
+   * 폼 입력 이름: 동일한 그룹의 라디오 버튼들이 공유하는 이름을 지정합니다.
+   */
+  name: string;
+
+  /**
+   * 필수 여부: true일 경우 사용자가 하나의 옵션을 반드시 선택해야 합니다.
+   * @default undefined
+   */
+  required?: boolean;
+
+  /**
+   * 라디오 그룹의 배치 방향을 결정합니다.
+   * 'horizontal'은 가로 배열, 'vertical'은 세로 배열을 의미합니다.
+   * @default undefined
+   */
+  orientation?: "horizontal" | "vertical";
+
+  /**
+   * 컴포넌트 내 Label과 Indicator의 정렬 방향을 결정합니다.
+   * 'ltr'은 왼쪽 정렬(왼쪽에서 오른쪽으로), 'rtl'은 오른쪽 정렬(오른쪽에서 왼쪽으로)입니다.
+   * @default "ltr"
+   */
+  dir?: "ltr" | "rtl";
+
+  /**
+   * 순환 여부: true이면 마지막 항목에서 첫 항목으로 순환할 수 있습니다.
+   * 방향키를 사용한 탐색 시 순환 효과를 제공합니다.
+   * @default false
+   */
+  loop?: boolean;
+}
+
+// eslint-disable-next-line no-empty-pattern
+export const RadioGroup = ({}: RadioGroupProps) => {
+  // TODO: RadioGroup 컴포넌트 구현
+  return null;
+};

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -1,8 +1,23 @@
+import type { ReactNode } from "react";
+
 export interface RadioGroupProps {
   /**
-   * 라디오 옵션 배열: 각 옵션은 label(표시 텍스트)과 value(실제 값)를 포함합니다.
+   * 라디오 버튼의 옵션 목록입니다.
+   * 2개 이상의 옵션을 제공해야 합니다.
    */
-  options: { label: string; value: string }[];
+  options: {
+    label: ReactNode;
+    value: string;
+    /**
+     * @default false
+     */
+    disabled?: boolean;
+  }[];
+
+  /**
+   * 폼 입력 이름: 동일한 그룹의 라디오 버튼들이 공유하는 이름을 지정합니다.
+   */
+  name: string;
 
   /**
    * 기본 선택값: 컴포넌트 초기 렌더링 시 선택될 값을 지정합니다.
@@ -20,18 +35,13 @@ export interface RadioGroupProps {
    * 값 변경 핸들러: 사용자가 선택을 변경할 때 호출되는 콜백 함수입니다.
    * @default undefined
    */
-  onValueChange?: (value: string) => void;
+  onChange?: (value: string) => void;
 
   /**
    * 비활성화 여부: true이면 모든 라디오 버튼이 비활성화되어 상호작용을 차단합니다.
    * @default false
    */
   disabled?: boolean;
-
-  /**
-   * 폼 입력 이름: 동일한 그룹의 라디오 버튼들이 공유하는 이름을 지정합니다.
-   */
-  name: string;
 
   /**
    * 필수 여부: true일 경우 사용자가 하나의 옵션을 반드시 선택해야 합니다.
@@ -45,20 +55,6 @@ export interface RadioGroupProps {
    * @default undefined
    */
   orientation?: "horizontal" | "vertical";
-
-  /**
-   * 컴포넌트 내 Label과 Indicator의 정렬 방향을 결정합니다.
-   * 'ltr'은 왼쪽 정렬(왼쪽에서 오른쪽으로), 'rtl'은 오른쪽 정렬(오른쪽에서 왼쪽으로)입니다.
-   * @default "ltr"
-   */
-  dir?: "ltr" | "rtl";
-
-  /**
-   * 순환 여부: true이면 마지막 항목에서 첫 항목으로 순환할 수 있습니다.
-   * 방향키를 사용한 탐색 시 순환 효과를 제공합니다.
-   * @default false
-   */
-  loop?: boolean;
 }
 
 // eslint-disable-next-line no-empty-pattern

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -1,19 +1,12 @@
-import type { ReactNode } from "react";
+import { type ReactNode } from "react";
 import type { Tone } from "../../tokens/colors";
 
-export interface RadioGroupProps {
+interface RadioGroupRootProps {
   /**
-   * 라디오 버튼의 옵션 목록입니다.
-   * 2개 이상의 옵션을 제공해야 합니다.
+   * RadioGroup의 자식 요소들입니다.
+   * RadioGroup.Item 컴포넌트를 포함해야 합니다.
    */
-  options: {
-    label: ReactNode;
-    value: string;
-    /**
-     * @default false
-     */
-    disabled?: boolean;
-  }[];
+  children: ReactNode;
 
   /**
    * 폼 입력 이름: 동일한 그룹의 라디오 버튼들이 공유하는 이름을 지정합니다.
@@ -61,8 +54,45 @@ export interface RadioGroupProps {
   tone?: Tone;
 }
 
-// eslint-disable-next-line no-empty-pattern
-export function RadioGroup({}: RadioGroupProps) {
-  // TODO: RadioGroup 컴포넌트 구현
+/**
+ * RadioGroup의 루트 컴포넌트입니다.
+ * 라디오 버튼 그룹을 정의하고 상태를.관리합니다.
+ */
+// eslint-disable-next-line react-refresh/only-export-components, no-empty-pattern
+function Root({}: RadioGroupRootProps) {
+  // TODO: 구현
   return null;
 }
+
+interface RadioGroupItemProps {
+  /**
+   * 라디오 버튼의 값입니다.
+   */
+  value: string;
+
+  /**
+   * 라디오 버튼의 자식 요소입니다.
+   */
+  children?: ReactNode;
+
+  /**
+   * 비활성화 여부: true이면 이 라디오 버튼이 비활성화됩니다.
+   * @default false
+   */
+  disabled?: boolean;
+}
+
+/**
+ * 라디오 그룹의 개별 항목입니다.
+ * 선택 가능한 단일 라디오 버튼을 나타냅니다.
+ */
+// eslint-disable-next-line react-refresh/only-export-components, no-empty-pattern
+function Item({}: RadioGroupItemProps) {
+  // TODO: 구현
+  return null;
+}
+
+export const RadioGroup = {
+  Root,
+  Item,
+};

--- a/src/components/RadioGroup/index.tsx
+++ b/src/components/RadioGroup/index.tsx
@@ -1,0 +1,1 @@
+export { RadioGroup } from "./RadioGroup";

--- a/src/components/RadioGroup/index.tsx
+++ b/src/components/RadioGroup/index.tsx
@@ -1,1 +1,0 @@
-export { RadioGroup } from "./RadioGroup";


### PR DESCRIPTION
@lylaminju 님과 함께 인터페이스 작성해봤습니다!

대체로 [Radix RadioGroup](https://www.radix-ui.com/primitives/docs/components/radio-group#api-reference)을 참고했는데요. 해당 컴포넌트의 모든 명세를 인터페이스에 다 반영하지는 않았습니다.
저희가 생각했을 때 적당한 수준에서 명세를 test.todo 형태로 작성했습니다.
해당 test.todo와 RadioGroup 컴포넌트의 interface를 읽었을 때

- 설명이 불충분해 이해가 가지 않는 부분,
- 해당 스펙이라면 고려해야 하는 부분인데 고려하지 않은 것들

등이 있다면 알려주시면 감사하겠습니다.