### PR TITLE
Storybook 버전 업데이트 그룹화 Dpendabot 설정

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    group:
+      storybook:
+        patterns:
+          - "storybook"
+          - "@storybook/*"
 
   - package-ecosystem: "github-actions"
     pull-request-branch-name:


### PR DESCRIPTION
#107, #108 처럼 Storybook의 특정 패키지가 다른 패키지보다 먼저 업데이트되는 일이 없도록 Dependabot 설정을 보완합니다.