### PR TITLE
React 버전 업데이트 그룹화 Dpendabot 설정

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
         patterns:
           - "storybook"
           - "@storybook/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
 
   - package-ecosystem: "github-actions"
     pull-request-branch-name:


### PR DESCRIPTION
PR #122 에서 발생하는 문제를 방지하기 위해서 React 관련 패키지들이 항상 동일한 버전으로 함께 업데이트되도록 Dpendabot을 설정합니다.

![Shot 2025-04-03 at 20 25 35](https://github.com/user-attachments/assets/1f03701f-4c95-42d3-91fe-0fd0f6bfae3b)

https://github.com/DaleStudy/daleui/actions/runs/14184596513/job/39737548850?pr=122