### PR TITLE
기여 가이드(CONTRIBUTING.md) 추가

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# 기여 가이드
+
+DaleUI에 기여하고 싶으신가요? 여러분의 기여를 환영합니다!
+
+자세한 기여 가이드는 [위키 기여 페이지](https://github.com/DaleStudy/daleui/wiki/Contributing)를 참고해주세요.


### PR DESCRIPTION
외부 기여자를 위한 안내를 제공하는 CONTRIBUTING.md 파일을 추가했습니다.
위키의 기여 가이드 페이지로 연결되는 링크를 포함하고 있습니다.

[외부/내부 기여자 분리 히스토리 참고](https://github.com/DaleStudy/daleui/issues/78#issuecomment-2777233694)