### PR TITLE
글꼴 변경 중 깨진 설정 복구

### DIFF
--- a/src/styles/globalCss.ts
+++ b/src/styles/globalCss.ts
@@ -2,7 +2,7 @@ import { defineGlobalStyles } from "@pandacss/dev";
 
 export const globalCss = defineGlobalStyles({
   ":root": {
-    "--global-font-body": "var(--fonts-pretendard)",
+    "--global-font-body": "var(--fonts-sans)",
     backgroundColor: "var(--colors-base)",
   },
   h1: {


### PR DESCRIPTION
PR #181 에서 폰트 변경 후 main 브랜치에 글꼴 설정이 깨진 것을 발견하여 긴급 조치합니다.

## Before

`--global-font-body` CSS 변수가 미정의 되어, 의도치 않게 `--font-fallback` CSS 변수가 사용됨

![Shot 2025-04-25 at 22 49 53](https://github.com/user-attachments/assets/b12a47fe-6036-4c57-aa14-4c1d2197cfe8)


## After

의도한데로 `Pretendard Variable`가 글꼴로 사용됨

![Shot 2025-04-25 at 22 56 52](https://github.com/user-attachments/assets/930545cb-6b3c-44b6-8ad4-bdf66e15b8b0)


