### PR TITLE
Vite와 Vitest이 함께 버전 업데이트되도록 Dependabot 설정

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,10 @@ updates:
           - "react-dom"
           - "@types/react"
           - "@types/react-dom"
+      vite:
+        patterns:
+          - "vite"
+          - "vitest"
 
   - package-ecosystem: "github-actions"
     pull-request-branch-name:


### PR DESCRIPTION
## 변경 사항

우연인지는 모르겠으나 PR #139 에서도 그랬고 PR #221 에서도 그랬고 Vite 만 업데이트 되면 Vitest 설정 부분에서 계속 타입 오류가 발생하는 것 같습니다. 혹시나 도움이 될까하여 둘을 한 번 묶어 봅니다.

## 목적

Depandabot이 Vite나 Vitest를 업데이할 때 발생하는 타입 오류 최소화

## 리뷰어에게

딱히 없음