### PR TITLE
Link 컴포넌트 스토리북 버그

### DIFF
--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -10,7 +10,7 @@ export default {
   },
   args: {
     children: "링크",
-    href: "#",
+    href: undefined,
   },
 } satisfies Meta<typeof Link>;
 
@@ -154,9 +154,7 @@ export const Security: StoryObj<typeof Link> = {
         <Link {...args} target="_blank">
           새 탭에서 열기 (보안 속성 자동 추가)
         </Link>
-        <Link {...args} target="_self">
-          같은 탭에서 열기
-        </Link>
+        <Link {...args}>같은 탭에서 열기</Link>
       </div>
     );
   },


### PR DESCRIPTION
## 변경 사항
- 무엇을 변경했나요? (예: 새 컴포넌트 추가, 디자인 수정, 문서 업데이트)

 

## 목적
- 왜 이 변경이 필요한가요? (예: 접근성 개선, 사용자 경험 향상)  
  - Basic : href 속성값을 '#'로 줘서 이동을 막는게 의도였지만, iframe url로 이동됨
  - Security : href값을 'https://www.naver.com/' 작성시 연결이 거부됨
  - weight 변경 시, 글자굵기는 변경되지만 underline의 굵기는 변경되지 않음 (CSS 속성(예: text-decoration-thickness) 참고)
  - 명암비가 낮고 (muted = true) & Tone이 warning인 경우 웹접근성 통과 1개 안됨 (size가 2xl 이상부터는 웹접근성 통과)

## 리뷰어에게
- 특별히 확인해 주셨으면 하는 부분이 있나요? (예: 호버 상태, 모바일 뷰포트)  
