### PR TITLE
링크 컴포넌트 폰트 크기 증가시 underline 굵기도 같이 증가(draft)

### DIFF
--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -374,5 +374,8 @@ export const UnderlineThickness: StoryObj<typeof Link> = {
     size: {
       control: false,
     },
+    underline: {
+      control: false,
+    },
   },
 };

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -634,5 +634,6 @@ const styles = cva({
     muted: false,
     underline: true,
     size: "md",
+    weight: "normal",
   },
 });


### PR DESCRIPTION
## 변경 사항

- 무엇을 변경했나요? (예: 새 컴포넌트 추가, 디자인 수정, 문서 업데이트)

  - link의 underline을 font size 와 font weight의 따라서 굵기 및 text와의 간격을 조정하는 variant를 추가했습니다.
  - textDecorationThickness
      size \ weight | normal | medium | semibold | bold
      -- | -- | -- | -- | --
      xs | 1 | 1 | 1 | 1
      sm | 1 | 1 | 1 | 2
      md | 1 | 1 | 2 | 2
      lg | 1 | 2 | 2 | 2
      xl | 2 | 2 | 2 | 3
      2xl | 2 | 2 | 3 | 3
      3xl | 2 | 2 | 3 | 3
      4xl | 2 | 3 | 3 | 4
      5xl | 3 | 3 | 4 | 4
      6xl | 3 | 4 | 4 | 5
      7xl | 4 | 4 | 5 | 6
      8xl | 4 | 5 | 6 | 8  
  - textUnderlineOffset
      size \ weight | normal | medium | semibold | bold
      -- | -- | -- | -- | --
      xs | 2 | 2.5 | 2.5 | 3
      sm | 2.5 | 2.5 | 3 | 3
      md | 2.5 | 3 | 3 | 4
      lg | 3 | 3 | 4 | 4
      xl | 3 | 4 | 4 | 5
      2xl | 4 | 4 | 5 | 6
      3xl | 4 | 5 | 6 | 7
      4xl | 5 | 6 | 7 | 8
      5xl | 6 | 7 | 8 | 9
      6xl | 7 | 8 | 9 | 10
      7xl | 8 | 9 | 10 | 12
      8xl | 9 | 10 | 12| 14
      
      ![image](https://github.com/user-attachments/assets/11fc3100-5483-49c6-bb79-dc8a311a9c2b)



## 목적

- 왜 이 변경이 필요한가요? (예: 접근성 개선, 사용자 경험 향상)

  - link의 underline이 font size에 따라서만 굵기 조정이되고 weight에 따라서 변경되지 않아서 팀원들의 요구사항에 따라 변경하였습니다.

## 리뷰어에게

- 특별히 확인해 주셨으면 하는 부분이 있나요? (예: 호버 상태, 모바일 뷰포트)

  - 모든 조건의 compundVariant를 만들었는데 조건이 너무 많다보니 가독성이 떨어지는 하드코딩 덩어리가 만들어졌습니다. 그렇다고 동적스타일을 넣기에는 빌드타임에서 css를 만드는 pandaCSS에 맞지 않는것 같아서 고민이 됩니다.
