### PR TITLE
컴포넌트 스타일 문법 통일

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -69,10 +69,10 @@ const styles = cva({
     transition: "0.2s",
     lineHeight: "1",
     outline: "0",
-    _disabled: {
+    "&:disabled": {
       cursor: "not-allowed",
     },
-    _focusVisible: {
+    "&:focus-visible": {
       outline: "2px solid",
       outlineOffset: "2px",
       outlineColor: "border.brand.focus",

--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -41,12 +41,22 @@ test("체크박스에 체크 시, tone 속성이 올바르게 적용됨", async 
   expect(infoCheckbox).toHaveAttribute("data-state", "checked");
 
   // Check for correct background colors based on tone
-  expect(brandCheckbox).toHaveClass("checked:bg_bgSolid.brand");
-  expect(neutralCheckbox).toHaveClass("checked:bg_bgSolid.neutral");
-  expect(dangerCheckbox).toHaveClass("checked:bg_bgSolid.danger");
-  expect(warningCheckbox).toHaveClass("checked:bg_bgSolid.warning");
-  expect(successCheckbox).toHaveClass("checked:bg_bgSolid.success");
-  expect(infoCheckbox).toHaveClass("checked:bg_bgSolid.info");
+  expect(brandCheckbox).toHaveClass(
+    "[&[data-state='checked']]:bg_bgSolid.brand",
+  );
+  expect(neutralCheckbox).toHaveClass(
+    "[&[data-state='checked']]:bg_bgSolid.neutral",
+  );
+  expect(dangerCheckbox).toHaveClass(
+    "[&[data-state='checked']]:bg_bgSolid.danger",
+  );
+  expect(warningCheckbox).toHaveClass(
+    "[&[data-state='checked']]:bg_bgSolid.warning",
+  );
+  expect(successCheckbox).toHaveClass(
+    "[&[data-state='checked']]:bg_bgSolid.success",
+  );
+  expect(infoCheckbox).toHaveClass("[&[data-state='checked']]:bg_bgSolid.info");
 });
 
 test("체크된 상태와 체크되지않은 상태가 올바르게 렌더링됨", () => {
@@ -72,15 +82,14 @@ test("disabled 속성이 올바르게 적용됨", () => {
   expect(disabledUncheckedCheckbox).toBeDisabled();
   expect(enabledCheckbox).not.toBeDisabled();
 
-  // Check for opacity class that indicates disabled state
   expect(disabledCheckedCheckbox).toHaveClass(
-    "checked:bg_bg.neutral.disabled!",
+    "[&[data-state='checked']]:bg_bg.neutral.disabled!",
   );
   expect(disabledCheckedCheckbox).toHaveClass(
-    "checked:bd-c_bg.neutral.disabled!",
+    "[&[data-state='checked']]:bd-c_bg.neutral.disabled!",
   );
   expect(disabledUncheckedCheckbox).toHaveClass(
-    "disabled:bd-c_border.neutral.disabled",
+    "[&:disabled]:bd-c_border.neutral.disabled",
   );
 });
 

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -49,7 +49,7 @@ export const Checkbox = ({
         gap: "8",
         cursor: "pointer",
         color: "fg.neutral",
-        _disabled: {
+        "&:disabled": {
           cursor: "not-allowed",
           color: "fg.neutral.disabled",
         },
@@ -111,12 +111,12 @@ const styles = cva({
       bg: "bg.neutral.hover",
       color: "fg.neutral.hover",
     },
-    _focusVisible: {
+    "&:focus-visible": {
       outline: "2px solid",
       outlineOffset: "2px",
       outlineColor: "border.brand.focus",
     },
-    _disabled: {
+    "&:disabled": {
       borderColor: "border.neutral.disabled",
       bg: "transparent!",
       cursor: "not-allowed",
@@ -125,42 +125,42 @@ const styles = cva({
   variants: {
     tone: {
       brand: {
-        _checked: {
+        "&[data-state='checked']": {
           bg: "bgSolid.brand",
           borderColor: "bgSolid.brand",
           color: "fgSolid.brand",
         },
       },
       neutral: {
-        _checked: {
+        "&[data-state='checked']": {
           bg: "bgSolid.neutral",
           borderColor: "bgSolid.neutral",
           color: "fgSolid.neutral",
         },
       },
       danger: {
-        _checked: {
+        "&[data-state='checked']": {
           bg: "bgSolid.danger",
           borderColor: "bgSolid.danger",
           color: "fgSolid.danger",
         },
       },
       warning: {
-        _checked: {
+        "&[data-state='checked']": {
           bg: "bgSolid.warning",
           borderColor: "bgSolid.warning",
           color: "fgSolid.warning",
         },
       },
       success: {
-        _checked: {
+        "&[data-state='checked']": {
           bg: "bgSolid.success",
           borderColor: "bgSolid.success",
           color: "fgSolid.success",
         },
       },
       info: {
-        _checked: {
+        "&[data-state='checked']": {
           bg: "bgSolid.info",
           borderColor: "bgSolid.info",
           color: "fgSolid.info",
@@ -169,7 +169,7 @@ const styles = cva({
     },
     disabled: {
       true: {
-        _checked: {
+        "&[data-state='checked']": {
           bg: "bg.neutral.disabled!",
           borderColor: "bg.neutral.disabled!",
           color: "fg.neutral.disabled!",


### PR DESCRIPTION
## 변경 사항

칼라 토큰 구현 과정에서 웹 표준 선택자와 Panda CSS에서 제공하는 단축 문법이 혼재되게 되었습니다. 추후 하나의 팀으로서 컴포넌트 스타일을 할 때 혼선이 될 수 있는 부분이라서 웹 표준 문법을 사용하도록 통일하였습니다.

![Shot 2025-06-21 at 13 46 54](https://github.com/user-attachments/assets/624b9c85-dd27-48f8-8cea-c883039b5799)

웹 표준 선택자와 PandaCSS 문법을 사용했을 때의 trade-off에 대해서는 https://github.com/DaleStudy/daleui/pull/251#discussion_r2155792311 를 참조 바랍니다.

## 목적

일관적인 컴포넌트 스타일링

## 리뷰어에게

저는 웹 표준 CSS 문법이든 Panda CSS 문법이든 일관성만 지킬 수 있다면 모두 열려있습니다. 혹시 Panda CSS 문법으로 통일하는 것을 제안하고 싶으시다면 편하게 알려주세요.