### PR TITLE
크로매틱 URL 생성 시 커밋 해시 사용으로 37자 제한 문제 해결

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -8,8 +8,8 @@ jobs:
     steps:
       - id: gen_url
         run: |
-          # Dependabot can create branches with names that include `/` or `.`, which are not allowed in a URL.
-          URL=https://$(sed 's/[\.\/]/\-/g' <<< '${{ github.ref_name }}')--675790d317ba346348aa3490.chromatic.com
+          # Use commit hash instead of branch name to avoid 37-character limit
+          URL=https://${{ github.sha }}--675790d317ba346348aa3490.chromatic.com
           echo "url=$URL" >> $GITHUB_OUTPUT
     outputs:
       url: ${{ steps.gen_url.outputs.url }}


### PR DESCRIPTION
## 변경 사항

- 무엇을 변경했나요? (예: 새 컴포넌트 추가, 디자인 수정, 문서 업데이트)
  - GitHub Actions의 크로매틱 워크플로우에서 URL 생성 방식을 브랜치명에서 커밋 해시로 변경하였습니다.
  
## 목적

- 왜 이 변경이 필요한가요? (예: 접근성 개선, 사용자 경험 향상)
  - 브랜치명이 37자를 초과할 경우 크로매틱 URL이 잘려서 접근 불가능해서 개선하였습니다.
  - 브랜치명 길이나 특수문자에 관계없이 안정적인 URL 생성이 가능합니다.
  - Dependabot과 같은 긴 브랜치명으로 인한 CI 파이프라인 실패를 방지합니다.
  
## 리뷰어에게

- 특별히 확인해 주셨으면 하는 부분이 있나요? (예: 호버 상태, 모바일 뷰포트)
  - [공식문서](https://www.chromatic.com/docs/permalinks/)를 참고하여 수정하였습니다.
