### PR TITLE
Typography 토큰 업데이트

### DIFF
--- a/src/tokens/typography.mdx
+++ b/src/tokens/typography.mdx
@@ -130,6 +130,18 @@ import {
   fontFamily={fonts.sans.value}
 />
 
+##### Label.lg.underline
+
+<Typeset
+  fontSizes={[fontSizes.lg.value]}
+  fontWeight={fontWeights.medium.value}
+  lineHeight={lineHeights.tight.value}
+  letterSpacing={letterSpacings.balanced.value}
+  sampleText="누구든지 사용할 수 있는 Customizable Design System"
+  fontFamily={fonts.sans.value}
+  style={{ textDecoration: "underline" }}
+/>
+
 #### Label.md
 
 <Typeset
@@ -141,6 +153,18 @@ import {
   fontFamily={fonts.sans.value}
 />
 
+##### Label.md.underline
+
+<Typeset
+  fontSizes={[fontSizes.md.value]}
+  fontWeight={fontWeights.medium.value}
+  lineHeight={lineHeights.tight.value}
+  letterSpacing={letterSpacings.balanced.value}
+  sampleText="누구든지 사용할 수 있는 Customizable Design System"
+  fontFamily={fonts.sans.value}
+  style={{ textDecoration: "underline" }}
+/>
+
 #### Label.sm
 
 <Typeset
@@ -150,6 +174,18 @@ import {
   letterSpacing={letterSpacings.balanced.value}
   sampleText="누구든지 사용할 수 있는 Customizable Design System"
   fontFamily={fonts.sans.value}
+/>
+
+##### Label.sm.underline
+
+<Typeset
+  fontSizes={[fontSizes.sm.value]}
+  fontWeight={fontWeights.medium.value}
+  lineHeight={lineHeights.tight.value}
+  letterSpacing={letterSpacings.balanced.value}
+  sampleText="누구든지 사용할 수 있는 Customizable Design System"
+  fontFamily={fonts.sans.value}
+  style={{ textDecoration: "underline" }}
 />
 
 ### Caption

--- a/src/tokens/typography.mdx
+++ b/src/tokens/typography.mdx
@@ -119,74 +119,49 @@ import {
 
 ### Label
 
-#### Label.lg
+{[
+{
+title: "Label.lg",
+fontSizes: [fontSizes.lg.value],
+},
+{
+title: "Label.lg.underline",
+fontSizes: [fontSizes.lg.value],
+underline: true,
+},
+{
+title: "Label.md",
+fontSizes: [fontSizes.md.value],
+},
+{
+title: "Label.md.underline",
+fontSizes: [fontSizes.md.value],
+underline: true,
+},
+{
+title: "Label.sm",
+fontSizes: [fontSizes.sm.value],
+},
+{
+title: "Label.sm.underline",
+fontSizes: [fontSizes.sm.value],
+underline: true,
+},
+].map(({ title, fontSizes, underline }) => (
 
-<Typeset
-  fontSizes={[fontSizes.lg.value]}
-  fontWeight={fontWeights.medium.value}
-  lineHeight={lineHeights.tight.value}
-  letterSpacing={letterSpacings.balanced.value}
-  sampleText="누구든지 사용할 수 있는 Customizable Design System"
-  fontFamily={fonts.sans.value}
-/>
-
-##### Label.lg.underline
-
-<Typeset
-  fontSizes={[fontSizes.lg.value]}
-  fontWeight={fontWeights.medium.value}
-  lineHeight={lineHeights.tight.value}
-  letterSpacing={letterSpacings.balanced.value}
-  sampleText="누구든지 사용할 수 있는 Customizable Design System"
-  fontFamily={fonts.sans.value}
-  style={{ textDecoration: "underline" }}
-/>
-
-#### Label.md
-
-<Typeset
-  fontSizes={[fontSizes.md.value]}
-  fontWeight={fontWeights.medium.value}
-  lineHeight={lineHeights.tight.value}
-  letterSpacing={letterSpacings.balanced.value}
-  sampleText="누구든지 사용할 수 있는 Customizable Design System"
-  fontFamily={fonts.sans.value}
-/>
-
-##### Label.md.underline
-
-<Typeset
-  fontSizes={[fontSizes.md.value]}
-  fontWeight={fontWeights.medium.value}
-  lineHeight={lineHeights.tight.value}
-  letterSpacing={letterSpacings.balanced.value}
-  sampleText="누구든지 사용할 수 있는 Customizable Design System"
-  fontFamily={fonts.sans.value}
-  style={{ textDecoration: "underline" }}
-/>
-
-#### Label.sm
-
-<Typeset
-  fontSizes={[fontSizes.sm.value]}
-  fontWeight={fontWeights.medium.value}
-  lineHeight={lineHeights.tight.value}
-  letterSpacing={letterSpacings.balanced.value}
-  sampleText="누구든지 사용할 수 있는 Customizable Design System"
-  fontFamily={fonts.sans.value}
-/>
-
-##### Label.sm.underline
-
-<Typeset
-  fontSizes={[fontSizes.sm.value]}
-  fontWeight={fontWeights.medium.value}
-  lineHeight={lineHeights.tight.value}
-  letterSpacing={letterSpacings.balanced.value}
-  sampleText="누구든지 사용할 수 있는 Customizable Design System"
-  fontFamily={fonts.sans.value}
-  style={{ textDecoration: "underline" }}
-/>
+<div key={title}>
+  <h4>{title}</h4>
+  <Typeset
+    fontSizes={fontSizes}
+    fontWeight={fontWeights.medium.value}
+    lineHeight={lineHeights.tight.value}
+    letterSpacing={letterSpacings.balanced.value}
+    sampleText="누구든지 사용할 수 있는 Customizable Design System"
+    fontFamily={fonts.sans.value}
+    style={{ textDecoration: underline ? "underline" : "none" }}
+  />
+</div>
+))}
 
 ### Caption
 

--- a/src/tokens/typography.mdx
+++ b/src/tokens/typography.mdx
@@ -14,148 +14,179 @@ import {
 
 ### Display
 
-{[
-{
-title: "Display.lg",
-fontSizes: [fontSizes["8xl"].value],
-},
-{
-title: "Display.md",
-fontSizes: [fontSizes["7xl"].value],
-},
-{
-title: "Display.sm",
-fontSizes: [fontSizes["5xl"].value],
-},
-].map(({ title, fontSizes }) => (
+#### Display.lg
 
-<div key={title}>
-  <h4>{title}</h4>
-  <Typeset
-    fontSizes={fontSizes}
-    fontWeight={fontWeights.bold.value}
-    lineHeight={lineHeights.tight.value}
-    letterSpacing={letterSpacings.tight.value}
-    sampleText="누구든지 사용할 수 있는 Customizable Design System"
-    fontFamily={fonts.sans.value}
-  />
-</div>
-))}
+<Typeset
+  fontSizes={[fontSizes["8xl"].value]}
+  fontWeight={fontWeights.bold.value}
+  lineHeight={lineHeights.tight.value}
+  letterSpacing={letterSpacings.tight.value}
+  sampleText="누구든지 사용할 수 있는 Customizable Design System"
+  fontFamily={fonts.sans.value}
+/>
+
+#### Display.md
+
+<Typeset
+  fontSizes={[fontSizes["7xl"].value]}
+  fontWeight={fontWeights.bold.value}
+  lineHeight={lineHeights.tight.value}
+  letterSpacing={letterSpacings.tight.value}
+  sampleText="누구든지 사용할 수 있는 Customizable Design System"
+  fontFamily={fonts.sans.value}
+/>
+
+#### Display.sm
+
+<Typeset
+  fontSizes={[fontSizes["5xl"].value]}
+  fontWeight={fontWeights.bold.value}
+  lineHeight={lineHeights.tight.value}
+  letterSpacing={letterSpacings.tight.value}
+  sampleText="누구든지 사용할 수 있는 Customizable Design System"
+  fontFamily={fonts.sans.value}
+/>
 
 ### Title
 
-{[
-{
-title: "Title.lg",
-fontSizes: [fontSizes["4xl"].value],
-fontWeight: fontWeights.semibold.value,
-lineHeight: lineHeights.tight.value,
-},
-{
-title: "Title.md",
-fontSizes: [fontSizes["3xl"].value],
-fontWeight: fontWeights.semibold.value,
-lineHeight: lineHeights.tight.value,
-},
-{
-title: "Title.sm",
-fontSizes: [fontSizes["2xl"].value],
-fontWeight: fontWeights.medium.value,
-lineHeight: lineHeights.tight.value,
-},
-].map(({ title, fontSizes, fontWeight, lineHeight }) => (
+#### Title.lg
 
-<div key={title}>
-  <h4>{title}</h4>
-  <Typeset
-    fontSizes={fontSizes}
-    fontWeight={fontWeight}
-    lineHeight={lineHeight}
-    letterSpacing={letterSpacings.balanced.value}
-    sampleText="누구든지 사용할 수 있는 Customizable Design System"
-    fontFamily={fonts.sans.value}
-  />
-</div>
-))}
+<Typeset
+  fontSizes={[fontSizes["4xl"].value]}
+  fontWeight={fontWeights.semibold.value}
+  lineHeight={lineHeights.tight.value}
+  letterSpacing={letterSpacings.balanced.value}
+  sampleText="누구든지 사용할 수 있는 Customizable Design System"
+  fontFamily={fonts.sans.value}
+/>
+
+#### Title.md
+
+<Typeset
+  fontSizes={[fontSizes["3xl"].value]}
+  fontWeight={fontWeights.semibold.value}
+  lineHeight={lineHeights.tight.value}
+  letterSpacing={letterSpacings.balanced.value}
+  sampleText="누구든지 사용할 수 있는 Customizable Design System"
+  fontFamily={fonts.sans.value}
+/>
+
+#### Title.sm
+
+<Typeset
+  fontSizes={[fontSizes["2xl"].value]}
+  fontWeight={fontWeights.medium.value}
+  lineHeight={lineHeights.tight.value}
+  letterSpacing={letterSpacings.balanced.value}
+  sampleText="누구든지 사용할 수 있는 Customizable Design System"
+  fontFamily={fonts.sans.value}
+/>
 
 ### Body
 
-{[
-{
-title: "Body.lg",
-fontSizes: [fontSizes.lg.value],
-fontWeight: fontWeights.normal.value,
-},
-{
-title: "Body.md",
-fontSizes: [fontSizes.md.value],
-fontWeight: fontWeights.normal.value,
-},
-{
-title: "Body.sm",
-fontSizes: [fontSizes.sm.value],
-fontWeight: fontWeights.semibold.value,
-},
-].map(({ title, fontSizes, fontWeight }) => (
+#### Body.lg
 
-<div key={title}>
-  <h4>{title}</h4>
-  <Typeset
-    fontSizes={fontSizes}
-    fontWeight={fontWeight}
-    lineHeight={lineHeights.balanced.value}
-    letterSpacing={letterSpacings.balanced.value}
-    sampleText="누구든지 사용할 수 있는 Customizable Design System"
-    fontFamily={fonts.sans.value}
-  />
-</div>
-))}
+<Typeset
+  fontSizes={[fontSizes.lg.value]}
+  fontWeight={fontWeights.normal.value}
+  lineHeight={lineHeights.balanced.value}
+  letterSpacing={letterSpacings.balanced.value}
+  sampleText="누구든지 사용할 수 있는 Customizable Design System"
+  fontFamily={fonts.sans.value}
+/>
+
+#### Body.md
+
+<Typeset
+  fontSizes={[fontSizes.md.value]}
+  fontWeight={fontWeights.normal.value}
+  lineHeight={lineHeights.balanced.value}
+  letterSpacing={letterSpacings.balanced.value}
+  sampleText="누구든지 사용할 수 있는 Customizable Design System"
+  fontFamily={fonts.sans.value}
+/>
+
+#### Body.sm
+
+<Typeset
+  fontSizes={[fontSizes.sm.value]}
+  fontWeight={fontWeights.semibold.value}
+  lineHeight={lineHeights.balanced.value}
+  letterSpacing={letterSpacings.balanced.value}
+  sampleText="누구든지 사용할 수 있는 Customizable Design System"
+  fontFamily={fonts.sans.value}
+/>
 
 ### Label
 
-{[
-{
-title: "Label.lg",
-fontSizes: [fontSizes.lg.value],
-},
-{
-title: "Label.lg.underline",
-fontSizes: [fontSizes.lg.value],
-underline: true,
-},
-{
-title: "Label.md",
-fontSizes: [fontSizes.md.value],
-},
-{
-title: "Label.md.underline",
-fontSizes: [fontSizes.md.value],
-underline: true,
-},
-{
-title: "Label.sm",
-fontSizes: [fontSizes.sm.value],
-},
-{
-title: "Label.sm.underline",
-fontSizes: [fontSizes.sm.value],
-underline: true,
-},
-].map(({ title, fontSizes, underline }) => (
+#### Label.lg
 
-<div key={title}>
-  <h4>{title}</h4>
-  <Typeset
-    fontSizes={fontSizes}
-    fontWeight={fontWeights.medium.value}
-    lineHeight={lineHeights.tight.value}
-    letterSpacing={letterSpacings.balanced.value}
-    sampleText="누구든지 사용할 수 있는 Customizable Design System"
-    fontFamily={fonts.sans.value}
-    style={{ textDecoration: underline ? "underline" : "none" }}
-  />
-</div>
-))}
+<Typeset
+  fontSizes={[fontSizes.lg.value]}
+  fontWeight={fontWeights.medium.value}
+  lineHeight={lineHeights.tight.value}
+  letterSpacing={letterSpacings.balanced.value}
+  sampleText="누구든지 사용할 수 있는 Customizable Design System"
+  fontFamily={fonts.sans.value}
+/>
+
+#### Label.lg.underline
+
+<Typeset
+  fontSizes={[fontSizes.lg.value]}
+  fontWeight={fontWeights.medium.value}
+  lineHeight={lineHeights.tight.value}
+  letterSpacing={letterSpacings.balanced.value}
+  sampleText="누구든지 사용할 수 있는 Customizable Design System"
+  fontFamily={fonts.sans.value}
+  style={{ textDecoration: "underline" }}
+/>
+
+#### Label.md
+
+<Typeset
+  fontSizes={[fontSizes.md.value]}
+  fontWeight={fontWeights.medium.value}
+  lineHeight={lineHeights.tight.value}
+  letterSpacing={letterSpacings.balanced.value}
+  sampleText="누구든지 사용할 수 있는 Customizable Design System"
+  fontFamily={fonts.sans.value}
+/>
+
+#### Label.md.underline
+
+<Typeset
+  fontSizes={[fontSizes.md.value]}
+  fontWeight={fontWeights.medium.value}
+  lineHeight={lineHeights.tight.value}
+  letterSpacing={letterSpacings.balanced.value}
+  sampleText="누구든지 사용할 수 있는 Customizable Design System"
+  fontFamily={fonts.sans.value}
+  style={{ textDecoration: "underline" }}
+/>
+
+#### Label.sm
+
+<Typeset
+  fontSizes={[fontSizes.sm.value]}
+  fontWeight={fontWeights.medium.value}
+  lineHeight={lineHeights.tight.value}
+  letterSpacing={letterSpacings.balanced.value}
+  sampleText="누구든지 사용할 수 있는 Customizable Design System"
+  fontFamily={fonts.sans.value}
+/>
+
+#### Label.sm.underline
+
+<Typeset
+  fontSizes={[fontSizes.sm.value]}
+  fontWeight={fontWeights.medium.value}
+  lineHeight={lineHeights.tight.value}
+  letterSpacing={letterSpacings.balanced.value}
+  sampleText="누구든지 사용할 수 있는 Customizable Design System"
+  fontFamily={fonts.sans.value}
+  style={{ textDecoration: "underline" }}
+/>
 
 ### Caption
 
@@ -196,46 +227,61 @@ underline: true,
 
 ### 글꼴 굵기
 
-{Object.entries(fontWeights).map(([name, {value}]) => (
+#### normal(400)
 
-<>
-  <h4>
-    {name}({value})
-  </h4>
-  <Typeset
-    fontSizes={[fontSizes.md.value]}
-    fontWeight={value}
-    sampleText="달레 UI 디자인 System"
-    fontFamily={fonts.sans.value}
-  />
-</>
-))}
+<Typeset
+  fontSizes={[fontSizes.md.value]}
+  fontWeight={fontWeights.normal.value}
+  sampleText="달레 UI 디자인 System"
+  fontFamily={fonts.sans.value}
+/>
+
+#### medium(500)
+
+<Typeset
+  fontSizes={[fontSizes.md.value]}
+  fontWeight={fontWeights.medium.value}
+  sampleText="달레 UI 디자인 System"
+  fontFamily={fonts.sans.value}
+/>
+
+#### semibold(600)
+
+<Typeset
+  fontSizes={[fontSizes.md.value]}
+  fontWeight={fontWeights.semibold.value}
+  sampleText="달레 UI 디자인 System"
+  fontFamily={fonts.sans.value}
+/>
+
+#### bold(700)
+
+<Typeset
+  fontSizes={[fontSizes.md.value]}
+  fontWeight={fontWeights.bold.value}
+  sampleText="달레 UI 디자인 System"
+  fontFamily={fonts.sans.value}
+/>
 
 ### 글꼴 패밀리
 
-{[
-{
-title: "Sans (Pretendard Variable)",
-fontFamily: fonts.sans.value,
-sampleText: "깔끔하고 읽기 쉬운 본문용 폰트입니다.",
-},
-{
-title: "Mono (JetBrains Mono)",
-fontFamily: fonts.mono.value,
-sampleText: "const code = 'monospace font for code';",
-},
-].map(({ title, fontFamily, sampleText }) => (
+#### Sans (Pretendard Variable)
 
-<div key={title}>
-  <h4>{title}</h4>
-  <Typeset
-    fontSizes={[fontSizes.md.value]}
-    fontWeight={fontWeights.normal.value}
-    sampleText={sampleText}
-    fontFamily={fontFamily}
-  />
-</div>
-))}
+<Typeset
+  fontSizes={[fontSizes.md.value]}
+  fontWeight={fontWeights.normal.value}
+  sampleText="깔끔하고 읽기 쉬운 본문용 폰트입니다."
+  fontFamily={fonts.sans.value}
+/>
+
+#### Mono (JetBrains Mono)
+
+<Typeset
+  fontSizes={[fontSizes.md.value]}
+  fontWeight={fontWeights.normal.value}
+  sampleText="const code = 'monospace font for code';"
+  fontFamily={fonts.mono.value}
+/>
 
 ### Design
 

--- a/src/tokens/typography.mdx
+++ b/src/tokens/typography.mdx
@@ -14,108 +14,102 @@ import {
 
 ### Display
 
-#### Display.lg
+{[
+{
+title: "Display.lg",
+fontSizes: [fontSizes["8xl"].value],
+},
+{
+title: "Display.md",
+fontSizes: [fontSizes["7xl"].value],
+},
+{
+title: "Display.sm",
+fontSizes: [fontSizes["5xl"].value],
+},
+].map(({ title, fontSizes }) => (
 
-<Typeset
-  fontSizes={[fontSizes["8xl"].value]}
-  fontWeight={fontWeights.bold.value}
-  lineHeight={lineHeights.tight.value}
-  letterSpacing={letterSpacings.tight.value}
-  sampleText="누구든지 사용할 수 있는 Customizable Design System"
-  fontFamily={fonts.sans.value}
-/>
-
-#### Display.md
-
-<Typeset
-  fontSizes={[fontSizes["7xl"].value]}
-  fontWeight={fontWeights.bold.value}
-  lineHeight={lineHeights.tight.value}
-  letterSpacing={letterSpacings.tight.value}
-  sampleText="누구든지 사용할 수 있는 Customizable Design System"
-  fontFamily={fonts.sans.value}
-/>
-
-#### Display.sm
-
-<Typeset
-  fontSizes={[fontSizes["5xl"].value]}
-  fontWeight={fontWeights.bold.value}
-  lineHeight={lineHeights.tight.value}
-  letterSpacing={letterSpacings.tight.value}
-  sampleText="누구든지 사용할 수 있는 Customizable Design System"
-  fontFamily={fonts.sans.value}
-/>
+<div key={title}>
+  <h4>{title}</h4>
+  <Typeset
+    fontSizes={fontSizes}
+    fontWeight={fontWeights.bold.value}
+    lineHeight={lineHeights.tight.value}
+    letterSpacing={letterSpacings.tight.value}
+    sampleText="누구든지 사용할 수 있는 Customizable Design System"
+    fontFamily={fonts.sans.value}
+  />
+</div>
+))}
 
 ### Title
 
-#### Title.lg
+{[
+{
+title: "Title.lg",
+fontSizes: [fontSizes["4xl"].value],
+fontWeight: fontWeights.semibold.value,
+lineHeight: lineHeights.tight.value,
+},
+{
+title: "Title.md",
+fontSizes: [fontSizes["3xl"].value],
+fontWeight: fontWeights.semibold.value,
+lineHeight: lineHeights.tight.value,
+},
+{
+title: "Title.sm",
+fontSizes: [fontSizes["2xl"].value],
+fontWeight: fontWeights.medium.value,
+lineHeight: lineHeights.tight.value,
+},
+].map(({ title, fontSizes, fontWeight, lineHeight }) => (
 
-<Typeset
-  fontSizes={[fontSizes["4xl"].value]}
-  fontWeight={fontWeights.semibold.value}
-  lineHeight={lineHeights.tight.value}
-  letterSpacing={letterSpacings.balanced.value}
-  sampleText="누구든지 사용할 수 있는 Customizable Design System"
-  fontFamily={fonts.sans.value}
-/>
-
-#### Title.md
-
-<Typeset
-  fontSizes={[fontSizes["3xl"].value]}
-  fontWeight={fontWeights.semibold.value}
-  lineHeight={lineHeights.tight.value}
-  letterSpacing={letterSpacings.balanced.value}
-  sampleText="누구든지 사용할 수 있는 Customizable Design System"
-  fontFamily={fonts.sans.value}
-/>
-
-#### Title.sm
-
-<Typeset
-  fontSizes={[fontSizes["2xl"].value]}
-  fontWeight={fontWeights.medium.value}
-  lineHeight={lineHeights.tight.value}
-  letterSpacing={letterSpacings.balanced.value}
-  sampleText="누구든지 사용할 수 있는 Customizable Design System"
-  fontFamily={fonts.sans.value}
-/>
+<div key={title}>
+  <h4>{title}</h4>
+  <Typeset
+    fontSizes={fontSizes}
+    fontWeight={fontWeight}
+    lineHeight={lineHeight}
+    letterSpacing={letterSpacings.balanced.value}
+    sampleText="누구든지 사용할 수 있는 Customizable Design System"
+    fontFamily={fonts.sans.value}
+  />
+</div>
+))}
 
 ### Body
 
-#### Body.lg
+{[
+{
+title: "Body.lg",
+fontSizes: [fontSizes.lg.value],
+fontWeight: fontWeights.normal.value,
+},
+{
+title: "Body.md",
+fontSizes: [fontSizes.md.value],
+fontWeight: fontWeights.normal.value,
+},
+{
+title: "Body.sm",
+fontSizes: [fontSizes.sm.value],
+fontWeight: fontWeights.semibold.value,
+},
+].map(({ title, fontSizes, fontWeight }) => (
 
-<Typeset
-  fontSizes={[fontSizes.lg.value]}
-  fontWeight={fontWeights.normal.value}
-  lineHeight={lineHeights.balanced.value}
-  letterSpacing={letterSpacings.balanced.value}
-  sampleText="누구든지 사용할 수 있는 Customizable Design System"
-  fontFamily={fonts.sans.value}
-/>
-
-#### Body.md
-
-<Typeset
-  fontSizes={[fontSizes.md.value]}
-  fontWeight={fontWeights.normal.value}
-  lineHeight={lineHeights.balanced.value}
-  letterSpacing={letterSpacings.balanced.value}
-  sampleText="누구든지 사용할 수 있는 Customizable Design System"
-  fontFamily={fonts.sans.value}
-/>
-
-#### Body.sm
-
-<Typeset
-  fontSizes={[fontSizes.sm.value]}
-  fontWeight={fontWeights.semibold.value}
-  lineHeight={lineHeights.balanced.value}
-  letterSpacing={letterSpacings.balanced.value}
-  sampleText="누구든지 사용할 수 있는 Customizable Design System"
-  fontFamily={fonts.sans.value}
-/>
+<div key={title}>
+  <h4>{title}</h4>
+  <Typeset
+    fontSizes={fontSizes}
+    fontWeight={fontWeight}
+    lineHeight={lineHeights.balanced.value}
+    letterSpacing={letterSpacings.balanced.value}
+    sampleText="누구든지 사용할 수 있는 Customizable Design System"
+    fontFamily={fonts.sans.value}
+  />
+</div>
+))}
 
 ### Label
 
@@ -219,23 +213,29 @@ underline: true,
 
 ### 글꼴 패밀리
 
-#### Sans (Pretendard Variable)
+{[
+{
+title: "Sans (Pretendard Variable)",
+fontFamily: fonts.sans.value,
+sampleText: "깔끔하고 읽기 쉬운 본문용 폰트입니다.",
+},
+{
+title: "Mono (JetBrains Mono)",
+fontFamily: fonts.mono.value,
+sampleText: "const code = 'monospace font for code';",
+},
+].map(({ title, fontFamily, sampleText }) => (
 
-<Typeset
-  fontSizes={[fontSizes.md.value]}
-  fontWeight={fontWeights.normal.value}
-  sampleText="깔끔하고 읽기 쉬운 본문용 폰트입니다."
-  fontFamily={fonts.sans.value}
-/>
-
-#### Mono (JetBrains Mono)
-
-<Typeset
-  fontSizes={[fontSizes.md.value]}
-  fontWeight={fontWeights.normal.value}
-  sampleText="const code = 'monospace font for code';"
-  fontFamily={fonts.mono.value}
-/>
+<div key={title}>
+  <h4>{title}</h4>
+  <Typeset
+    fontSizes={[fontSizes.md.value]}
+    fontWeight={fontWeights.normal.value}
+    sampleText={sampleText}
+    fontFamily={fontFamily}
+  />
+</div>
+))}
 
 ### Design
 

--- a/src/tokens/typography.ts
+++ b/src/tokens/typography.ts
@@ -95,6 +95,16 @@ export const textStyles = {
         lineHeight: "tight",
         letterSpacing: "balanced",
       },
+      underline: {
+        value: {
+          fontFamily: "sans",
+          fontSize: "lg",
+          fontWeight: "medium",
+          lineHeight: "tight",
+          letterSpacing: "balanced",
+          textDecoration: "underline",
+        },
+      },
     },
     md: {
       value: {
@@ -104,6 +114,16 @@ export const textStyles = {
         lineHeight: "tight",
         letterSpacing: "balanced",
       },
+      underline: {
+        value: {
+          fontFamily: "sans",
+          fontSize: "md",
+          fontWeight: "medium",
+          lineHeight: "tight",
+          letterSpacing: "balanced",
+          textDecoration: "underline",
+        },
+      },
     },
     sm: {
       value: {
@@ -112,6 +132,16 @@ export const textStyles = {
         fontWeight: "medium",
         lineHeight: "tight",
         letterSpacing: "balanced",
+      },
+      underline: {
+        value: {
+          fontFamily: "sans",
+          fontSize: "sm",
+          fontWeight: "medium",
+          lineHeight: "tight",
+          letterSpacing: "balanced",
+          textDecoration: "underline",
+        },
       },
     },
   },

--- a/src/tokens/typography.ts
+++ b/src/tokens/typography.ts
@@ -99,6 +99,11 @@ export const textStyles = {
       },
       underline: {
         value: {
+          fontFamily: "sans",
+          fontSize: "lg",
+          fontWeight: "medium",
+          lineHeight: "tight",
+          letterSpacing: "balanced",
           textDecoration: "underline",
         },
       },
@@ -115,6 +120,11 @@ export const textStyles = {
       },
       underline: {
         value: {
+          fontFamily: "sans",
+          fontSize: "md",
+          fontWeight: "medium",
+          lineHeight: "tight",
+          letterSpacing: "balanced",
           textDecoration: "underline",
         },
       },
@@ -131,6 +141,11 @@ export const textStyles = {
       },
       underline: {
         value: {
+          fontFamily: "sans",
+          fontSize: "sm",
+          fontWeight: "medium",
+          lineHeight: "tight",
+          letterSpacing: "balanced",
           textDecoration: "underline",
         },
       },

--- a/src/tokens/typography.ts
+++ b/src/tokens/typography.ts
@@ -88,58 +88,49 @@ export const textStyles = {
   },
   label: {
     lg: {
-      value: {
-        fontFamily: "sans",
-        fontSize: "lg",
-        fontWeight: "medium",
-        lineHeight: "tight",
-        letterSpacing: "balanced",
-      },
-      underline: {
+      DEFAULT: {
         value: {
           fontFamily: "sans",
           fontSize: "lg",
           fontWeight: "medium",
           lineHeight: "tight",
           letterSpacing: "balanced",
+        },
+      },
+      underline: {
+        value: {
           textDecoration: "underline",
         },
       },
     },
     md: {
-      value: {
-        fontFamily: "sans",
-        fontSize: "md",
-        fontWeight: "medium",
-        lineHeight: "tight",
-        letterSpacing: "balanced",
-      },
-      underline: {
+      DEFAULT: {
         value: {
           fontFamily: "sans",
           fontSize: "md",
           fontWeight: "medium",
           lineHeight: "tight",
           letterSpacing: "balanced",
+        },
+      },
+      underline: {
+        value: {
           textDecoration: "underline",
         },
       },
     },
     sm: {
-      value: {
-        fontFamily: "sans",
-        fontSize: "sm",
-        fontWeight: "medium",
-        lineHeight: "tight",
-        letterSpacing: "balanced",
-      },
-      underline: {
+      DEFAULT: {
         value: {
           fontFamily: "sans",
           fontSize: "sm",
           fontWeight: "medium",
           lineHeight: "tight",
           letterSpacing: "balanced",
+        },
+      },
+      underline: {
+        value: {
           textDecoration: "underline",
         },
       },


### PR DESCRIPTION
## 변경 사항

- 무엇을 변경했나요? (예: 새 컴포넌트 추가, 디자인 수정, 문서 업데이트)

  - label.{size}.underline (sm, md, lg) 형태의 새로운 typography 토큰을 추가했습니다.
  - 기존에 피그마에서 label.{size} 스타일에 textDecoration: underline을 수동으로 적용했으나, 텍스트 수정 시 스타일이 깨지는 이슈가 있었습니다.
  - 이를 해결하기 위해 underline 속성을 포함한 스타일을 별도 토큰으로 분리 정의했습니다.
![Screenshot 2025-07-01 at 19 10 44](https://github.com/user-attachments/assets/ca1f175b-798b-4ff3-a1f1-e93fe96c4a73)

## 목적

- 왜 이 변경이 필요한가요? (예: 접근성 개선, 사용자 경험 향상)

  - 피그마에서 텍스트 수정 시 발생하는 underline 스타일 깨짐 현상 해결
  - 피그마와 개발 환경 간의 스타일 일치

## 리뷰어에게

- 특별히 확인해 주셨으면 하는 부분이 있나요? (예: 호버 상태, 모바일 뷰포트)

  - 스타일 적용 결과가 의도한 대로 잘 적용되는지 확인 부탁드립니다.
