### PR TITLE
Tag 컴포넌트 구현

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -13,5 +13,8 @@ const config: StorybookConfig = {
     name: "@storybook/react-vite",
     options: {},
   },
+  typescript: {
+    reactDocgen: "react-docgen-typescript",
+  },
 };
 export default config;

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -1,0 +1,203 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { hstack, vstack } from "../../../styled-system/patterns";
+import { Tag } from "./Tag";
+
+export default {
+  component: Tag,
+  parameters: {
+    layout: "centered",
+  },
+  args: {
+    children: "태그",
+    tone: "neutral",
+    removable: false,
+    link: false,
+  },
+} satisfies Meta<typeof Tag>;
+
+export const Basic: StoryObj<typeof Tag> = {};
+
+export const Tones: StoryObj<typeof Tag> = {
+  render: (args) => {
+    return (
+      <div className={vstack({ gap: "16" })}>
+        <div className={hstack({ gap: "8" })}>
+          <Tag {...args} tone="neutral">
+            Neutral
+          </Tag>
+          <Tag {...args} tone="brand">
+            Brand
+          </Tag>
+          <Tag {...args} tone="danger">
+            Danger
+          </Tag>
+        </div>
+        <div className={hstack({ gap: "8" })}>
+          <Tag {...args} tone="warning">
+            Warning
+          </Tag>
+          <Tag {...args} tone="success">
+            Success
+          </Tag>
+          <Tag {...args} tone="info">
+            Info
+          </Tag>
+        </div>
+      </div>
+    );
+  },
+  argTypes: {
+    children: {
+      control: false,
+    },
+    tone: {
+      control: false,
+    },
+  },
+};
+
+export const Link: StoryObj<typeof Tag> = {
+  render: (args) => {
+    return (
+      <div className={vstack({ gap: "16" })}>
+        <div className={hstack({ gap: "8" })}>
+          <Tag {...args}>기본 태그</Tag>
+          <Tag {...args} link>
+            링크 태그 (호버 해보세요)
+          </Tag>
+          <Tag
+            {...args}
+            {...({
+              link: true,
+              href: "https://example.com",
+              target: "_blank",
+            } as const)}
+          >
+            외부 링크 태그
+          </Tag>
+        </div>
+        <div>
+          <p style={{ fontSize: "12px", color: "#666", marginTop: "8px" }}>
+            링크 태그는 마우스를 올리거나 키보드로 포커스할 때 상호작용 상태를
+            보여줍니다. 세 번째 태그는 실제 외부 링크로 연결됩니다.
+          </p>
+        </div>
+      </div>
+    );
+  },
+  argTypes: {
+    children: {
+      control: false,
+    },
+    link: {
+      control: false,
+    },
+  },
+};
+
+export const Removable: StoryObj<typeof Tag> = {
+  render: (args) => {
+    return (
+      <div className={vstack({ gap: "16" })}>
+        <div>
+          <h3
+            style={{ marginBottom: "8px", fontSize: "14px", fontWeight: "600" }}
+          >
+            제거 가능한 태그들 (X 버튼 클릭 시 제거됨)
+          </h3>
+          <div className={hstack({ gap: "8" })}>
+            <Tag {...args} tone="brand" removable>
+              제거 가능 태그
+            </Tag>
+            <Tag {...args} tone="success" removable>
+              제거 가능 + 성공 톤
+            </Tag>
+            <Tag {...args} tone="danger" removable>
+              제거 가능 + 위험 톤
+            </Tag>
+          </div>
+          <p style={{ fontSize: "12px", color: "#666", marginTop: "8px" }}>
+            각 태그의 X 버튼을 클릭하면 해당 태그가 제거됩니다.
+          </p>
+        </div>
+      </div>
+    );
+  },
+  argTypes: {
+    children: {
+      control: false,
+    },
+    tone: {
+      control: false,
+    },
+    removable: {
+      control: false,
+    },
+  },
+};
+
+export const Interactive: StoryObj<typeof Tag> = {
+  render: (args) => {
+    const handleTagClick = (tagText: string) => {
+      alert(`"${tagText}" 태그를 클릭했습니다! (제거되지 않음)`);
+    };
+
+    return (
+      <div className={vstack({ gap: "16" })}>
+        <div>
+          <h3
+            style={{ marginBottom: "8px", fontSize: "14px", fontWeight: "600" }}
+          >
+            링크 태그 (클릭 가능)
+          </h3>
+          <Tag {...args} tone="brand" link>
+            클릭 가능한 태그
+          </Tag>
+        </div>
+
+        <div>
+          <h3
+            style={{ marginBottom: "8px", fontSize: "14px", fontWeight: "600" }}
+          >
+            제거 가능한 태그 (X 버튼으로만 제거됨)
+          </h3>
+          <div className={hstack({ gap: "8" })}>
+            <Tag
+              {...args}
+              tone="danger"
+              removable
+              onClick={() => handleTagClick("제거 가능한 태그")}
+            >
+              제거 가능한 태그
+            </Tag>
+            <Tag
+              {...args}
+              tone="warning"
+              removable
+              onClick={() => handleTagClick("클릭해보세요 (제거 안됨)")}
+            >
+              클릭해보세요 (제거 안됨)
+            </Tag>
+          </div>
+          <p style={{ fontSize: "12px", color: "#666", marginTop: "8px" }}>
+            태그를 클릭하면 알림이 뜨고, X 버튼을 클릭하면 제거됩니다.
+          </p>
+        </div>
+      </div>
+    );
+  },
+  argTypes: {
+    children: {
+      control: false,
+    },
+    tone: {
+      control: false,
+    },
+    removable: {
+      control: false,
+    },
+    link: {
+      control: false,
+    },
+  },
+};

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { css } from "../../../styled-system/css";
 import { hstack, vstack } from "../../../styled-system/patterns";
 import { Tag } from "./Tag";
 
@@ -81,7 +82,13 @@ export const Link: StoryObj<typeof Tag> = {
           </Tag>
         </div>
         <div>
-          <p style={{ fontSize: "12px", color: "#666", marginTop: "8px" }}>
+          <p
+            className={css({
+              fontSize: "sm",
+              color: "fg.neutral",
+              marginTop: "8",
+            })}
+          >
             링크 태그는 마우스를 올리거나 키보드로 포커스할 때 상호작용 상태를
             보여줍니다. 세 번째 태그는 실제 외부 링크로 연결됩니다.
           </p>
@@ -105,7 +112,11 @@ export const Removable: StoryObj<typeof Tag> = {
       <div className={vstack({ gap: "16" })}>
         <div>
           <h3
-            style={{ marginBottom: "8px", fontSize: "14px", fontWeight: "600" }}
+            className={css({
+              marginBottom: "8",
+              fontSize: "sm",
+              fontWeight: "semibold",
+            })}
           >
             제거 가능한 태그들 (X 버튼 클릭 시 제거됨)
           </h3>
@@ -120,7 +131,13 @@ export const Removable: StoryObj<typeof Tag> = {
               제거 가능 + 위험 톤
             </Tag>
           </div>
-          <p style={{ fontSize: "12px", color: "#666", marginTop: "8px" }}>
+          <p
+            className={css({
+              fontSize: "sm",
+              color: "fg.neutral",
+              marginTop: "8",
+            })}
+          >
             각 태그의 X 버튼을 클릭하면 해당 태그가 제거됩니다.
           </p>
         </div>
@@ -150,7 +167,11 @@ export const Interactive: StoryObj<typeof Tag> = {
       <div className={vstack({ gap: "16" })}>
         <div>
           <h3
-            style={{ marginBottom: "8px", fontSize: "14px", fontWeight: "600" }}
+            className={css({
+              marginBottom: "8",
+              fontSize: "sm",
+              fontWeight: "semibold",
+            })}
           >
             링크 태그 (클릭 가능)
           </h3>
@@ -161,7 +182,11 @@ export const Interactive: StoryObj<typeof Tag> = {
 
         <div>
           <h3
-            style={{ marginBottom: "8px", fontSize: "14px", fontWeight: "600" }}
+            className={css({
+              marginBottom: "8",
+              fontSize: "sm",
+              fontWeight: "semibold",
+            })}
           >
             제거 가능한 태그 (X 버튼으로만 제거됨)
           </h3>
@@ -183,7 +208,13 @@ export const Interactive: StoryObj<typeof Tag> = {
               클릭해보세요 (제거 안됨)
             </Tag>
           </div>
-          <p style={{ fontSize: "12px", color: "#666", marginTop: "8px" }}>
+          <p
+            className={css({
+              fontSize: "sm",
+              color: "fg.neutral",
+              marginTop: "8",
+            })}
+          >
             태그를 클릭하면 알림이 뜨고, X 버튼을 클릭하면 제거됩니다.
           </p>
         </div>

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -6,6 +6,10 @@ export default {
   component: Tag,
   parameters: {
     layout: "centered",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/mQ2ETYC6LXGOwVETov3CgO/Dale-UI-Kit?node-id=1906-1035&t=hkjHysQiJbNEnBw1-0",
+    },
   },
   args: {
     children: "태그",

--- a/src/components/Tag/Tag.test.tsx
+++ b/src/components/Tag/Tag.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { expect, test, vi } from "vitest";
+import { Tag } from "./Tag";
+
+test("텍스트와 함께 태그를 올바르게 렌더링한다", () => {
+  render(<Tag>테스트 태그</Tag>);
+  expect(screen.getByText("테스트 태그")).toBeInTheDocument();
+});
+
+test("tone 속성을 올바르게 적용한다", () => {
+  render(
+    <div>
+      <Tag tone="neutral">Neutral</Tag>
+      <Tag tone="brand">Brand</Tag>
+      <Tag tone="danger">Danger</Tag>
+    </div>,
+  );
+
+  const neutralTag = screen.getByText("Neutral");
+  const brandTag = screen.getByText("Brand");
+  const dangerTag = screen.getByText("Danger");
+
+  expect(neutralTag).toBeInTheDocument();
+  expect(brandTag).toHaveClass("bg_bgSolid.brand");
+  expect(dangerTag).toHaveClass("bg_bgSolid.danger");
+});
+
+test("link 속성을 올바르게 적용한다", () => {
+  render(<Tag link>링크 태그</Tag>);
+  const linkTag = screen.getByText("링크 태그");
+  expect(linkTag).toHaveAttribute("role", "link");
+  expect(linkTag).toHaveAttribute("tabIndex", "0");
+});
+
+test("link 태그에 href 속성을 올바르게 적용한다", () => {
+  const tagProps = {
+    link: true as const,
+    href: "https://example.com",
+    target: "_blank" as const,
+    children: "외부 링크 태그",
+  };
+
+  render(<Tag {...tagProps} />);
+  const linkTag = screen.getByText("외부 링크 태그");
+  expect(linkTag.tagName).toBe("A");
+  expect(linkTag).toHaveAttribute("href", "https://example.com");
+  expect(linkTag).toHaveAttribute("target", "_blank");
+  expect(linkTag).toHaveAttribute("role", "link");
+});
+
+test("removable 속성을 올바르게 적용한다", () => {
+  render(
+    <div>
+      <Tag removable>제거 가능 태그 1</Tag>
+      <Tag removable>제거 가능 태그 2</Tag>
+      <Tag removable>제거 가능 태그 3</Tag>
+    </div>,
+  );
+
+  const removableTags = screen.getAllByLabelText("제거");
+  expect(removableTags).toHaveLength(3);
+
+  removableTags.forEach((removeButton) => {
+    expect(removeButton).toHaveAttribute("type", "button");
+    expect(removeButton).toHaveAttribute("tabIndex", "-1");
+  });
+});
+
+test("제거 버튼이 올바르게 렌더링된다", async () => {
+  const user = userEvent.setup();
+  render(
+    <Tag tone="brand" removable>
+      제거 가능한 태그
+    </Tag>,
+  );
+
+  const removeButton = screen.getByLabelText("제거");
+  expect(removeButton).toBeInTheDocument();
+  expect(removeButton).toHaveAttribute("tabIndex", "-1");
+  await user.click(removeButton);
+});
+
+test("링크 태그가 올바르게 동작한다", async () => {
+  const handleClick = vi.fn();
+  const user = userEvent.setup();
+
+  render(
+    <Tag tone="success" link onClick={handleClick}>
+      클릭 가능한 태그
+    </Tag>,
+  );
+
+  const tag = screen.getByText("클릭 가능한 태그");
+  await user.click(tag);
+  expect(handleClick).toHaveBeenCalledTimes(1);
+});
+
+test("제거 버튼 클릭 시 이벤트 전파를 중단한다", async () => {
+  const handleClick = vi.fn();
+  const user = userEvent.setup();
+
+  render(
+    <div onClick={handleClick}>
+      <Tag tone="warning" link removable>
+        링크 + 제거 가능 태그
+      </Tag>
+    </div>,
+  );
+
+  const removeButton = screen.getByLabelText("제거");
+  await user.click(removeButton);
+  expect(handleClick).not.toHaveBeenCalled();
+});
+
+test("제거 버튼 클릭 시 Tag 엘리먼트를 제거한다", async () => {
+  const user = userEvent.setup();
+
+  render(
+    <div>
+      <Tag tone="danger" removable>
+        제거될 태그
+      </Tag>
+      <Tag tone="success">남아있을 태그</Tag>
+    </div>,
+  );
+
+  expect(screen.getByText("제거될 태그")).toBeInTheDocument();
+  expect(screen.getByText("남아있을 태그")).toBeInTheDocument();
+
+  const removeButton = screen.getByLabelText("제거");
+  await user.click(removeButton);
+
+  expect(screen.queryByText("제거될 태그")).not.toBeInTheDocument();
+  expect(screen.getByText("남아있을 태그")).toBeInTheDocument();
+});
+
+test("X 버튼만 클릭했을 때만 제거되고, 태그 자체 클릭으로는 제거되지 않는다", async () => {
+  const handleClick = vi.fn();
+  const user = userEvent.setup();
+
+  render(
+    <Tag tone="brand" removable onClick={handleClick}>
+      테스트 태그
+    </Tag>,
+  );
+
+  const tag = screen.getByText("테스트 태그");
+  const removeButton = screen.getByLabelText("제거");
+
+  // 태그 클릭 - 제거되지 않아야 함
+  await user.click(tag);
+  expect(handleClick).toHaveBeenCalledTimes(1);
+  expect(screen.getByText("테스트 태그")).toBeInTheDocument();
+
+  // X 버튼 클릭 - 제거되어야 함
+  await user.click(removeButton);
+  expect(screen.queryByText("테스트 태그")).not.toBeInTheDocument();
+});

--- a/src/components/Tag/Tag.test.tsx
+++ b/src/components/Tag/Tag.test.tsx
@@ -63,7 +63,7 @@ test("removable 속성을 올바르게 적용한다", () => {
 
   removableTags.forEach((removeButton) => {
     expect(removeButton).toHaveAttribute("type", "button");
-    expect(removeButton).toHaveAttribute("tabIndex", "-1");
+    expect(removeButton).not.toHaveAttribute("tabIndex", "-1");
   });
 });
 
@@ -77,7 +77,7 @@ test("제거 버튼이 올바르게 렌더링된다", async () => {
 
   const removeButton = screen.getByLabelText("제거");
   expect(removeButton).toBeInTheDocument();
-  expect(removeButton).toHaveAttribute("tabIndex", "-1");
+  expect(removeButton).not.toHaveAttribute("tabIndex", "-1");
   await user.click(removeButton);
 });
 
@@ -156,4 +156,96 @@ test("X 버튼만 클릭했을 때만 제거되고, 태그 자체 클릭으로�
   // X 버튼 클릭 - 제거되어야 함
   await user.click(removeButton);
   expect(screen.queryByText("테스트 태그")).not.toBeInTheDocument();
+});
+
+test("제거 버튼에 focus가 가능하다", async () => {
+  const user = userEvent.setup();
+
+  render(<Tag removable>Focus 테스트 태그</Tag>);
+
+  const removeButton = screen.getByLabelText("제거");
+
+  // 제거 버튼에 focus 가능한지 확인
+  await user.tab();
+  expect(removeButton).toHaveFocus();
+});
+
+test("제거 버튼이 키보드로 동작한다", async () => {
+  const user = userEvent.setup();
+
+  render(<Tag removable>키보드 테스트 태그</Tag>);
+
+  const removeButton = screen.getByLabelText("제거");
+
+  // 제거 버튼에 focus
+  await user.tab();
+  expect(removeButton).toHaveFocus();
+
+  // Enter 키로 제거
+  await user.keyboard("{Enter}");
+  expect(screen.queryByText("키보드 테스트 태그")).not.toBeInTheDocument();
+});
+
+test("제거 버튼이 Space 키로 동작한다", async () => {
+  const user = userEvent.setup();
+
+  render(<Tag removable>Space 키 테스트 태그</Tag>);
+
+  const removeButton = screen.getByLabelText("제거");
+
+  // 제거 버튼에 focus
+  await user.tab();
+  expect(removeButton).toHaveFocus();
+
+  // Space 키로 제거
+  await user.keyboard(" ");
+  expect(screen.queryByText("Space 키 테스트 태그")).not.toBeInTheDocument();
+});
+
+test("링크 + 제거 가능 태그에서 제거 버튼 키보드 동작 시 링크가 클릭되지 않는다", async () => {
+  const handleClick = vi.fn();
+  const user = userEvent.setup();
+
+  render(
+    <Tag link removable onClick={handleClick}>
+      링크 + 제거 가능 태그
+    </Tag>,
+  );
+
+  const removeButton = screen.getByLabelText("제거");
+
+  // 제거 버튼에 focus - 링크가 있으므로 두 번 tab
+  await user.tab(); // 링크에 포커스
+  await user.tab(); // 제거 버튼에 포커스
+  expect(removeButton).toHaveFocus();
+
+  // Enter 키로 제거 - 링크 클릭 핸들러가 호출되지 않아야 함
+  await user.keyboard("{Enter}");
+  expect(handleClick).not.toHaveBeenCalled();
+  expect(screen.queryByText("링크 + 제거 가능 태그")).not.toBeInTheDocument();
+});
+
+test("링크 + 제거 가능 태그에서 제거 버튼 Space 키 동작 시 링크가 클릭되지 않는다", async () => {
+  const handleClick = vi.fn();
+  const user = userEvent.setup();
+
+  render(
+    <Tag link removable onClick={handleClick}>
+      링크 + 제거 가능 태그 Space
+    </Tag>,
+  );
+
+  const removeButton = screen.getByLabelText("제거");
+
+  // 제거 버튼에 focus - 링크가 있으므로 두 번 tab
+  await user.tab(); // 링크에 포커스
+  await user.tab(); // 제거 버튼에 포커스
+  expect(removeButton).toHaveFocus();
+
+  // Space 키로 제거 - 링크 클릭 핸들러가 호출되지 않아야 함
+  await user.keyboard(" ");
+  expect(handleClick).not.toHaveBeenCalled();
+  expect(
+    screen.queryByText("링크 + 제거 가능 태그 Space"),
+  ).not.toBeInTheDocument();
 });

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,11 +1,13 @@
 import {
   type HTMLAttributes,
+  type KeyboardEvent,
   type MouseEvent,
   type ReactNode,
   useState,
 } from "react";
 import { cva } from "../../../styled-system/css";
 import type { Tone } from "../../tokens/colors";
+import { Icon } from "../Icon/Icon";
 
 type BaseTagProps = {
   /** 태그 내용 */
@@ -50,6 +52,14 @@ export function Tag({
     setIsRemoved(true);
   };
 
+  const handleRemoveKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsRemoved(true);
+    }
+  };
+
   const Element = link ? "a" : "span";
 
   if (isRemoved) {
@@ -58,7 +68,7 @@ export function Tag({
 
   return (
     <Element
-      className={styles({ tone, removable, link })}
+      className={styles({ tone, link })}
       role={link ? "link" : undefined}
       tabIndex={link ? 0 : undefined}
       onClick={onClick}
@@ -69,11 +79,11 @@ export function Tag({
         <button
           type="button"
           onClick={handleRemoveClick}
+          onKeyDown={handleRemoveKeyDown}
           className={removeButtonStyles()}
           aria-label="제거"
-          tabIndex={-1}
         >
-          ×
+          <Icon name="x" size="xs" />
         </button>
       )}
     </Element>
@@ -89,9 +99,7 @@ const styles = cva({
     py: "4",
     height: "8",
     borderRadius: "full",
-    fontSize: "sm",
-    fontWeight: "medium",
-    lineHeight: "tight",
+    textStyle: "label.sm",
     cursor: "default",
     transition: "0.2s",
   },
@@ -107,9 +115,8 @@ const styles = cva({
           bg: "bgSolid.neutral.active",
         },
         "&:focus-visible": {
-          outlineWidth: "lg",
-          outlineStyle: "solid",
-          outlineColor: "border.neutral.active",
+          outlineWidth: "{borderWidths.lg}",
+          outlineColor: "border.brand.focus",
           outlineOffset: "2",
         },
       },
@@ -123,8 +130,7 @@ const styles = cva({
           bg: "bgSolid.brand.active",
         },
         "&:focus-visible": {
-          outlineWidth: "lg",
-          outlineStyle: "solid",
+          outlineWidth: "{borderWidths.lg}",
           outlineColor: "border.brand.focus",
           outlineOffset: "2",
         },
@@ -139,9 +145,8 @@ const styles = cva({
           bg: "bgSolid.danger.active",
         },
         "&:focus-visible": {
-          outlineWidth: "lg",
-          outlineStyle: "solid",
-          outlineColor: "border.danger",
+          outlineWidth: "{borderWidths.lg}",
+          outlineColor: "border.brand.focus",
           outlineOffset: "2",
         },
       },
@@ -155,9 +160,8 @@ const styles = cva({
           bg: "bgSolid.warning.active",
         },
         "&:focus-visible": {
-          outlineWidth: "lg",
-          outlineStyle: "solid",
-          outlineColor: "border.warning",
+          outlineWidth: "{borderWidths.lg}",
+          outlineColor: "border.brand.focus",
           outlineOffset: "2",
         },
       },
@@ -171,9 +175,8 @@ const styles = cva({
           bg: "bgSolid.success.active",
         },
         "&:focus-visible": {
-          outlineWidth: "lg",
-          outlineStyle: "solid",
-          outlineColor: "border.success",
+          outlineWidth: "{borderWidths.lg}",
+          outlineColor: "border.brand.focus",
           outlineOffset: "2",
         },
       },
@@ -187,16 +190,11 @@ const styles = cva({
           bg: "bgSolid.info.active",
         },
         "&:focus-visible": {
-          outlineWidth: "lg",
-          outlineStyle: "solid",
-          outlineColor: "border.info",
+          outlineWidth: "{borderWidths.lg}",
+          outlineColor: "border.brand.focus",
           outlineOffset: "2",
         },
       },
-    },
-    removable: {
-      true: {},
-      false: {},
     },
     link: {
       true: {
@@ -205,7 +203,6 @@ const styles = cva({
           textDecoration: "underline",
         },
       },
-      false: {},
     },
   },
 });
@@ -222,14 +219,12 @@ const removeButtonStyles = cva({
     bg: "transparent",
     color: "inherit",
     cursor: "pointer",
-    fontSize: "xs",
-    lineHeight: "tight",
     transition: "0.2s",
     "&:focus-visible": {
-      outlineWidth: "sm",
-      outlineStyle: "solid",
-      outlineColor: "border.neutral",
+      outlineWidth: "{borderWidths.lg}",
+      outlineColor: "border.brand.focus",
       outlineOffset: "2",
+      outlineStyle: "solid",
     },
   },
 });

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -104,6 +104,11 @@ const styles = cva({
     textStyle: "label.sm",
     cursor: "default",
     transition: "0.2s",
+    "&:focus-visible": {
+      outlineWidth: "{borderWidths.lg}",
+      outlineColor: "border.brand.focus",
+      outlineOffset: "2",
+    },
   },
   variants: {
     tone: {
@@ -116,11 +121,6 @@ const styles = cva({
         "&:active": {
           bg: "bgSolid.neutral.active",
         },
-        "&:focus-visible": {
-          outlineWidth: "{borderWidths.lg}",
-          outlineColor: "border.brand.focus",
-          outlineOffset: "2",
-        },
       },
       brand: {
         bg: "bgSolid.brand",
@@ -130,11 +130,6 @@ const styles = cva({
         },
         "&:active": {
           bg: "bgSolid.brand.active",
-        },
-        "&:focus-visible": {
-          outlineWidth: "{borderWidths.lg}",
-          outlineColor: "border.brand.focus",
-          outlineOffset: "2",
         },
       },
       danger: {
@@ -146,11 +141,6 @@ const styles = cva({
         "&:active": {
           bg: "bgSolid.danger.active",
         },
-        "&:focus-visible": {
-          outlineWidth: "{borderWidths.lg}",
-          outlineColor: "border.brand.focus",
-          outlineOffset: "2",
-        },
       },
       warning: {
         bg: "bgSolid.warning",
@@ -160,11 +150,6 @@ const styles = cva({
         },
         "&:active": {
           bg: "bgSolid.warning.active",
-        },
-        "&:focus-visible": {
-          outlineWidth: "{borderWidths.lg}",
-          outlineColor: "border.brand.focus",
-          outlineOffset: "2",
         },
       },
       success: {
@@ -176,11 +161,6 @@ const styles = cva({
         "&:active": {
           bg: "bgSolid.success.active",
         },
-        "&:focus-visible": {
-          outlineWidth: "{borderWidths.lg}",
-          outlineColor: "border.brand.focus",
-          outlineOffset: "2",
-        },
       },
       info: {
         bg: "bgSolid.info",
@@ -190,11 +170,6 @@ const styles = cva({
         },
         "&:active": {
           bg: "bgSolid.info.active",
-        },
-        "&:focus-visible": {
-          outlineWidth: "{borderWidths.lg}",
-          outlineColor: "border.brand.focus",
-          outlineOffset: "2",
         },
       },
     },

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -23,21 +23,21 @@ type TagPropsWithoutLink = BaseTagProps &
     link?: false;
   };
 
-export type TagProps = TagPropsWithLink | TagPropsWithoutLink;
+type TagProps = TagPropsWithLink | TagPropsWithoutLink;
 
 /**
  * - `tone` 속성으로 태그의 색조를 지정할 수 있습니다.
  * - `removable` 속성을 사용하여 제거 가능한 태그로 만들 수 있습니다.
  * - `link` 속성을 사용하여 링크 스타일을 적용할 수 있습니다.
  */
-export const Tag = ({
+export function Tag({
   children,
   tone = "neutral",
   removable = false,
   link = false,
   onClick,
   ...rest
-}: TagProps) => {
+}: TagProps) {
   const [isRemoved, setIsRemoved] = useState(false);
 
   const handleRemoveClick = (e: React.MouseEvent) => {
@@ -73,7 +73,7 @@ export const Tag = ({
       )}
     </Element>
   );
-};
+}
 
 const styles = cva({
   base: {

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -20,13 +20,13 @@ type BaseTagProps = {
 
 type TagPropsWithLink = BaseTagProps &
   Omit<HTMLAttributes<HTMLAnchorElement>, "style"> & {
-    /** 링크 여부 */
+    /** true시 a 태그, false/생략시 span 태그로 렌더링 */
     link: true;
   };
 
 type TagPropsWithoutLink = BaseTagProps &
   Omit<HTMLAttributes<HTMLSpanElement>, "style"> & {
-    /** 링크 여부 */
+    /** true시 a 태그, false/생략시 span 태그로 렌더링 */
     link?: false;
   };
 
@@ -36,6 +36,8 @@ type TagProps = TagPropsWithLink | TagPropsWithoutLink;
  * - `tone` 속성으로 태그의 색조를 지정할 수 있습니다.
  * - `removable` 속성을 사용하여 제거 가능한 태그로 만들 수 있습니다.
  * - `link` 속성을 사용하여 링크 스타일을 적용할 수 있습니다.
+ *   - `link={true}`일 때는 `a` 태그로 렌더링되며, `href`, `target` 등 `a` 태그의 모든 속성을 사용할 수 있습니다.
+ *   - `link={false}` 또는 생략시에는 `span` 태그로 렌더링됩니다.
  */
 export function Tag({
   children,

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,0 +1,230 @@
+import React, { type HTMLAttributes, useState } from "react";
+import { cva } from "../../../styled-system/css";
+import type { Tone } from "../../tokens/colors";
+
+type BaseTagProps = {
+  /** 태그 내용 */
+  children: React.ReactNode;
+  /** 색조 */
+  tone?: Tone;
+  /** 제거 가능 여부 */
+  removable?: boolean;
+};
+
+type TagPropsWithLink = BaseTagProps &
+  Omit<HTMLAttributes<HTMLAnchorElement>, "style"> & {
+    /** 링크 여부 */
+    link: true;
+  };
+
+type TagPropsWithoutLink = BaseTagProps &
+  Omit<HTMLAttributes<HTMLSpanElement>, "style"> & {
+    /** 링크 여부 */
+    link?: false;
+  };
+
+export type TagProps = TagPropsWithLink | TagPropsWithoutLink;
+
+/**
+ * - `tone` 속성으로 태그의 색조를 지정할 수 있습니다.
+ * - `removable` 속성을 사용하여 제거 가능한 태그로 만들 수 있습니다.
+ * - `link` 속성을 사용하여 링크 스타일을 적용할 수 있습니다.
+ */
+export const Tag = ({
+  children,
+  tone = "neutral",
+  removable = false,
+  link = false,
+  onClick,
+  ...rest
+}: TagProps) => {
+  const [isRemoved, setIsRemoved] = useState(false);
+
+  const handleRemoveClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setIsRemoved(true);
+  };
+
+  const Element = link ? "a" : "span";
+
+  if (isRemoved) {
+    return null;
+  }
+
+  return (
+    <Element
+      className={styles({ tone, removable, link })}
+      role={link ? "link" : undefined}
+      tabIndex={link ? 0 : undefined}
+      onClick={onClick}
+      {...rest}
+    >
+      {children}
+      {removable && (
+        <button
+          type="button"
+          onClick={handleRemoveClick}
+          className={removeButtonStyles()}
+          aria-label="제거"
+          tabIndex={-1}
+        >
+          ×
+        </button>
+      )}
+    </Element>
+  );
+};
+
+const styles = cva({
+  base: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "4",
+    px: "12",
+    py: "4",
+    height: "8",
+    borderRadius: "full",
+    fontSize: "sm",
+    fontWeight: "medium",
+    lineHeight: "tight",
+    cursor: "default",
+    transition: "0.2s",
+  },
+  variants: {
+    tone: {
+      neutral: {
+        bg: "bgSolid.neutral",
+        color: "fgSolid.neutral",
+        "&:hover": {
+          bg: "bgSolid.neutral.hover",
+        },
+        "&:active": {
+          bg: "bgSolid.neutral.active",
+        },
+        "&:focus-visible": {
+          outlineWidth: "lg",
+          outlineStyle: "solid",
+          outlineColor: "border.neutral.active",
+          outlineOffset: "2",
+        },
+      },
+      brand: {
+        bg: "bgSolid.brand",
+        color: "fgSolid.brand",
+        "&:hover": {
+          bg: "bgSolid.brand.hover",
+        },
+        "&:active": {
+          bg: "bgSolid.brand.active",
+        },
+        "&:focus-visible": {
+          outlineWidth: "lg",
+          outlineStyle: "solid",
+          outlineColor: "border.brand.focus",
+          outlineOffset: "2",
+        },
+      },
+      danger: {
+        bg: "bgSolid.danger",
+        color: "fgSolid.danger",
+        "&:hover": {
+          bg: "bgSolid.danger.hover",
+        },
+        "&:active": {
+          bg: "bgSolid.danger.active",
+        },
+        "&:focus-visible": {
+          outlineWidth: "lg",
+          outlineStyle: "solid",
+          outlineColor: "border.danger",
+          outlineOffset: "2",
+        },
+      },
+      warning: {
+        bg: "bgSolid.warning",
+        color: "fgSolid.warning",
+        "&:hover": {
+          bg: "bgSolid.warning.hover",
+        },
+        "&:active": {
+          bg: "bgSolid.warning.active",
+        },
+        "&:focus-visible": {
+          outlineWidth: "lg",
+          outlineStyle: "solid",
+          outlineColor: "border.warning",
+          outlineOffset: "2",
+        },
+      },
+      success: {
+        bg: "bgSolid.success",
+        color: "fgSolid.success",
+        "&:hover": {
+          bg: "bgSolid.success.hover",
+        },
+        "&:active": {
+          bg: "bgSolid.success.active",
+        },
+        "&:focus-visible": {
+          outlineWidth: "lg",
+          outlineStyle: "solid",
+          outlineColor: "border.success",
+          outlineOffset: "2",
+        },
+      },
+      info: {
+        bg: "bgSolid.info",
+        color: "fgSolid.info",
+        "&:hover": {
+          bg: "bgSolid.info.hover",
+        },
+        "&:active": {
+          bg: "bgSolid.info.active",
+        },
+        "&:focus-visible": {
+          outlineWidth: "lg",
+          outlineStyle: "solid",
+          outlineColor: "border.info",
+          outlineOffset: "2",
+        },
+      },
+    },
+    removable: {
+      true: {},
+      false: {},
+    },
+    link: {
+      true: {
+        cursor: "pointer",
+        "&:hover": {
+          textDecoration: "underline",
+        },
+      },
+      false: {},
+    },
+  },
+});
+
+const removeButtonStyles = cva({
+  base: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "4",
+    height: "4",
+    borderRadius: "full",
+    border: "none",
+    bg: "transparent",
+    color: "inherit",
+    cursor: "pointer",
+    fontSize: "xs",
+    lineHeight: "tight",
+    transition: "0.2s",
+    "&:focus-visible": {
+      outlineWidth: "sm",
+      outlineStyle: "solid",
+      outlineColor: "border.neutral",
+      outlineOffset: "2",
+    },
+  },
+});

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,10 +1,15 @@
-import React, { type HTMLAttributes, useState } from "react";
+import {
+  type HTMLAttributes,
+  type MouseEvent,
+  type ReactNode,
+  useState,
+} from "react";
 import { cva } from "../../../styled-system/css";
 import type { Tone } from "../../tokens/colors";
 
 type BaseTagProps = {
   /** 태그 내용 */
-  children: React.ReactNode;
+  children: ReactNode;
   /** 색조 */
   tone?: Tone;
   /** 제거 가능 여부 */
@@ -40,7 +45,7 @@ export function Tag({
 }: TagProps) {
   const [isRemoved, setIsRemoved] = useState(false);
 
-  const handleRemoveClick = (e: React.MouseEvent) => {
+  const handleRemoveClick = (e: MouseEvent) => {
     e.stopPropagation();
     setIsRemoved(true);
   };


### PR DESCRIPTION
> [!NOTE]
> 내부적으로 Icon 컴포넌트를 반영할 예정입니다!

# Tag 컴포넌트

다양한 상황에서 사용할 수 있는 태그 컴포넌트입니다. 정보를 분류하거나 상태를 표시하는 데 사용됩니다.

<img width="684" height="181" alt="image" src="https://github.com/user-attachments/assets/ec6981c9-1552-4d36-b3a5-1bd82b71ed4f" />

## 기본 사용법

```tsx
import { Tag } from '@/components/Tag';

// 기본 태그
<Tag>기본 태그</Tag>

// 색조가 있는 태그
<Tag tone="brand">브랜드 태그</Tag>
```

## Props

### BaseTagProps

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `children` | `React.ReactNode` | - | 태그 내용 |
| `tone` | `Tone` | `"neutral"` | 태그의 색조 (`neutral`, `brand`, `danger`, `warning`, `success`, `info`) |
| `removable` | `boolean` | `false` | 제거 가능 여부 |

### 조건부 Props

컴포넌트는 `link` prop에 따라 다른 타입을 가집니다:

#### 일반 태그 (link=false)
`HTMLSpanElement`의 모든 속성을 지원합니다.

#### 링크 태그 (link=true)
`HTMLAnchorElement`의 모든 속성을 지원합니다 (`href`, `target` 등).

## 사용 예제

### 색조별 태그

<img width="687" height="236" alt="image" src="https://github.com/user-attachments/assets/d142b78d-fe82-4630-b59a-150941e90e65" />

```tsx
<Tag tone="neutral">Neutral</Tag>
<Tag tone="brand">Brand</Tag>
<Tag tone="danger">Danger</Tag>
<Tag tone="warning">Warning</Tag>
<Tag tone="success">Success</Tag>
<Tag tone="info">Info</Tag>
```

### 제거 가능한 태그

<img width="684" height="240" alt="image" src="https://github.com/user-attachments/assets/cb583a0a-7c80-4019-ba61-651b0d180226" />

```tsx
<Tag removable tone="brand">
  제거 가능한 태그
</Tag>
```

제거 버튼을 클릭하면 태그가 DOM에서 제거됩니다.

### 링크 태그

<img width="664" height="241" alt="image" src="https://github.com/user-attachments/assets/ce8798ae-6e92-4dbf-9045-cc26bec9dfd6" />

```tsx
// 기본 링크 태그
<Tag link>클릭 가능한 태그</Tag>

// 외부 링크 태그
<Tag 
  link 
  href="https://example.com" 
  target="_blank"
  rel="noopener noreferrer"
>
  외부 링크 태그
</Tag>
```

## 주의사항

1. **이벤트 전파**: 제거 버튼 클릭 시 `stopPropagation()`을 호출하여 태그의 `onClick` 이벤트와 충돌하지 않습니다.
2. **타입 안전성**: `link` prop에 따라 올바른 HTML 속성만 허용됩니다.
3. **상태 관리**: 제거된 태그는 내부 상태로 관리되며, 부모 컴포넌트에서 별도 처리가 필요한 경우 `onClick` 핸들러를 사용하세요.

## TypeScript 지원

완전한 TypeScript 지원을 제공하며, `link` prop에 따른 조건부 타입을 통해 정확한 타입 추론을 제공합니다.

```tsx
// TypeScript에서 자동으로 올바른 타입을 추론합니다
const linkTag: TagPropsWithLink = {
  link: true,
  href: '/example', // HTMLAnchorElement 속성 사용 가능
  children: 'Link Tag'
};

const spanTag: TagPropsWithoutLink = {
  link: false, // 또는 생략
  onClick: () => {}, // HTMLSpanElement 속성 사용 가능
  children: 'Span Tag'
};
```
