### PR TITLE
[POC] Checkbox의 RadixUI를 BaseUI로 마이그레이션

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "daleui",
       "dependencies": {
-        "@radix-ui/react-checkbox": "^1.2.3",
+        "@base-ui-components/react": "^1.0.0-beta.2",
         "@radix-ui/react-radio-group": "^1.3.7",
         "axe-playwright": "^2.0.3",
         "chromatic": "^13.1.3",
@@ -125,6 +125,10 @@
 
     "@babel/types": ["@babel/types@7.27.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q=="],
 
+    "@base-ui-components/react": ["@base-ui-components/react@1.0.0-beta.2", "", { "dependencies": { "@babel/runtime": "^7.27.6", "@base-ui-components/utils": "0.1.0", "@floating-ui/react-dom": "^2.1.5", "@floating-ui/utils": "^0.2.10", "reselect": "^5.1.1", "tabbable": "^6.2.0", "use-sync-external-store": "^1.5.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-jfAUfSgXvsfr8mQi7r/6gLG8U1Ybr77NN8WK5IXXM0c/hBvFDBtvUfwDJACV0gXiYbSKpA+dRzZz01V1tULobA=="],
+
+    "@base-ui-components/utils": ["@base-ui-components/utils@0.1.0", "", { "dependencies": { "@babel/runtime": "^7.27.6", "@floating-ui/utils": "^0.2.10", "reselect": "^5.1.1", "use-sync-external-store": "^1.5.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-9+uaWyF1o/PgXqHLJnC81IIG0HlV3o9eFCQ5hWZDMx5NHrFk0rrwqEFGQOB8lti/rnbxNPi+kYYw1D4e8xSn/Q=="],
+
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@0.2.3", "", {}, "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="],
 
     "@chromatic-com/storybook": ["@chromatic-com/storybook@4.0.1", "", { "dependencies": { "@neoconfetti/react": "^1.0.0", "chromatic": "^12.0.0", "filesize": "^10.0.12", "jsonfile": "^6.1.0", "strip-ansi": "^7.1.0" }, "peerDependencies": { "storybook": "^0.0.0-0 || ^9.0.0 || ^9.1.0-0" } }, "sha512-GQXe5lyZl3yLewLJQyFXEpOp2h+mfN2bPrzYaOFNCJjO4Js9deKbRHTOSaiP2FRwZqDLdQwy2+SEGeXPZ94yYw=="],
@@ -210,6 +214,14 @@
     "@figspec/components": ["@figspec/components@1.0.3", "", { "dependencies": { "lit": "^2.1.3" } }, "sha512-fBwHzJ4ouuOUJEi+yBZIrOy+0/fAjB3AeTcIHTT1PRxLz8P63xwC7R0EsIJXhScIcc+PljGmqbbVJCjLsnaGYA=="],
 
     "@figspec/react": ["@figspec/react@1.0.4", "", { "dependencies": { "@figspec/components": "^1.0.1", "@lit-labs/react": "^1.0.2" }, "peerDependencies": { "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-jaPvkIef4d6NjsRiw91OZabrfdPH9FtoPGYcY5mpXjYEcdUqIq1aHtLq3SkMVyVysEapTEJ6yS8amy93MyXBEQ=="],
+
+    "@floating-ui/core": ["@floating-ui/core@1.7.3", "", { "dependencies": { "@floating-ui/utils": "^0.2.10" } }, "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.3", "", { "dependencies": { "@floating-ui/core": "^1.7.3", "@floating-ui/utils": "^0.2.10" } }, "sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag=="],
+
+    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.5", "", { "dependencies": { "@floating-ui/dom": "^1.7.3" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-HDO/1/1oH9fjj4eLgegrlH3dklZpHtUYYFiVwMUwfGvk9jWDRWqkklA2/NFScknrcNSspbV868WjXORvreDX+Q=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
 
     "@hapi/hoek": ["@hapi/hoek@9.3.0", "", {}, "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="],
 
@@ -323,8 +335,6 @@
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.2", "", {}, "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA=="],
 
-    "@radix-ui/react-checkbox": ["@radix-ui/react-checkbox@1.2.3", "", { "dependencies": { "@radix-ui/primitive": "1.1.2", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-presence": "1.1.4", "@radix-ui/react-primitive": "2.1.0", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-pHVzDYsnaDmBlAuwim45y3soIN8H4R7KbkSVirGhXO+R/kO2OLCe0eucUEbddaTcdMHHdzcIGHtZSMSQlA+apw=="],
-
     "@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw=="],
 
     "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
@@ -337,13 +347,13 @@
 
     "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA=="],
 
-    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.0", "", { "dependencies": { "@radix-ui/react-slot": "1.2.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-/J/FhLdK0zVcILOwt5g+dH4KnkonCtkVJsa2G6JmvbbtZfBEI1gMsO3QMjseL4F/SwfAMt1Vc/0XKYKq+xJ1sw=="],
+    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
     "@radix-ui/react-radio-group": ["@radix-ui/react-radio-group@1.3.7", "", { "dependencies": { "@radix-ui/primitive": "1.1.2", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-presence": "1.1.4", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-roving-focus": "1.1.10", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9w5XhD0KPOrm92OTTE0SysH3sYzHsSTHNvZgUBo/VZ80VdYyB5RneDbc0dKpURS24IxkoFRu/hI0i4XyfFwY6g=="],
 
     "@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.1.10", "", { "dependencies": { "@radix-ui/primitive": "1.1.2", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-dT9aOXUen9JSsxnMPv/0VqySQf5eDQ6LCk5Sw28kamz8wSOW2bJdlX2Bg5VUIIcV+6XlHpWTIuTPCf/UNIyq8Q=="],
 
-    "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ujc+V6r0HNDviYqIK3rW4ffgYiZ8g5DEHrGJVk4x7kTlLXRDILnKX9vAUYeIsLOoDpDJ0ujpqMkjH4w2ofuo6w=="],
+    "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
 
@@ -1367,6 +1377,8 @@
 
     "require-main-filename": ["require-main-filename@2.0.0", "", {}, "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="],
 
+    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
+
     "resolve": ["resolve@1.22.10", "", { "dependencies": { "is-core-module": "^2.16.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w=="],
 
     "resolve-cwd": ["resolve-cwd@3.0.0", "", { "dependencies": { "resolve-from": "^5.0.0" } }, "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg=="],
@@ -1459,6 +1471,8 @@
 
     "svg-parser": ["svg-parser@2.0.4", "", {}, "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="],
 
+    "tabbable": ["tabbable@6.2.0", "", {}, "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="],
+
     "table": ["table@6.9.0", "", { "dependencies": { "ajv": "^8.0.1", "lodash.truncate": "^4.4.2", "slice-ansi": "^4.0.0", "string-width": "^4.2.3", "strip-ansi": "^6.0.1" } }, "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A=="],
 
     "test-exclude": ["test-exclude@6.0.0", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^7.1.4", "minimatch": "^3.0.4" } }, "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w=="],
@@ -1524,6 +1538,8 @@
     "update-browserslist-db": ["update-browserslist-db@1.1.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.5.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
@@ -1629,6 +1645,10 @@
 
     "@babel/traverse/globals": ["globals@11.12.0", "", {}, "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="],
 
+    "@base-ui-components/react/@babel/runtime": ["@babel/runtime@7.28.3", "", {}, "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA=="],
+
+    "@base-ui-components/utils/@babel/runtime": ["@babel/runtime@7.28.3", "", {}, "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA=="],
+
     "@chromatic-com/storybook/chromatic": ["chromatic@12.1.1", "", { "peerDependencies": { "@chromatic-com/cypress": "^0.*.* || ^1.0.0", "@chromatic-com/playwright": "^0.*.* || ^1.0.0" }, "optionalPeers": ["@chromatic-com/cypress", "@chromatic-com/playwright"], "bin": { "chroma": "dist/bin.js", "chromatic": "dist/bin.js", "chromatic-cli": "dist/bin.js" } }, "sha512-vNe/PU4EvPN4V+d03Ym2mWBxqEkfbTCSfd0Z+PUMir0S/gKjbFK72FgTYz64j3k31UtrzMarB8EIzwFMxsDbjg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
@@ -1696,14 +1716,6 @@
     "@pandacss/node/prettier": ["prettier@3.2.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A=="],
 
     "@pandacss/postcss/postcss": ["postcss@8.4.49", "", { "dependencies": { "nanoid": "^3.3.7", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA=="],
-
-    "@radix-ui/react-collection/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-radio-group/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-roving-focus/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
     "@rollup/pluginutils/picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
 
@@ -2062,10 +2074,6 @@
     "@pandacss/node/postcss/nanoid": ["nanoid@3.3.9", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-SppoicMGpZvbF1l3z4x7No3OlIjP7QJvC9XR7AhZr1kL133KHnKPztkKDc+Ir4aJ/1VhTySrtKhrsycmrMQfvg=="],
 
     "@pandacss/postcss/postcss/nanoid": ["nanoid@3.3.9", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-SppoicMGpZvbF1l3z4x7No3OlIjP7QJvC9XR7AhZr1kL133KHnKPztkKDc+Ir4aJ/1VhTySrtKhrsycmrMQfvg=="],
-
-    "@radix-ui/react-radio-group/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-roving-focus/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@svgr/core/@babel/core/@babel/code-frame": ["@babel/code-frame@7.26.2", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.25.9", "js-tokens": "^4.0.0", "picocolors": "^1.0.0" } }, "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ=="],
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prepare": "panda codegen"
   },
   "dependencies": {
-    "@radix-ui/react-checkbox": "^1.2.3",
+    "@base-ui-components/react": "^1.0.0-beta.2",
     "@radix-ui/react-radio-group": "^1.3.7",
     "axe-playwright": "^2.0.3",
     "chromatic": "^13.1.3",

--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -32,31 +32,31 @@ test("체크박스에 체크 시, tone 속성이 올바르게 적용됨", async 
   await user.click(successCheckbox);
   await user.click(infoCheckbox);
 
-  // Check for data-state attribute which indicates checked state
-  expect(brandCheckbox).toHaveAttribute("data-state", "checked");
-  expect(neutralCheckbox).toHaveAttribute("data-state", "checked");
-  expect(dangerCheckbox).toHaveAttribute("data-state", "checked");
-  expect(warningCheckbox).toHaveAttribute("data-state", "checked");
-  expect(successCheckbox).toHaveAttribute("data-state", "checked");
-  expect(infoCheckbox).toHaveAttribute("data-state", "checked");
+  // Check for data-checked attribute which indicates checked state
+  expect(brandCheckbox).toHaveAttribute("data-checked");
+  expect(neutralCheckbox).toHaveAttribute("data-checked");
+  expect(dangerCheckbox).toHaveAttribute("data-checked");
+  expect(warningCheckbox).toHaveAttribute("data-checked");
+  expect(successCheckbox).toHaveAttribute("data-checked");
+  expect(infoCheckbox).toHaveAttribute("data-checked");
 
   // Check for correct background colors based on tone
   expect(brandCheckbox).toHaveClass(
-    "[&[data-state='checked']]:bg_bgSolid.brand",
+    "[&[data-checked='true']]:bg_bgSolid.brand",
   );
   expect(neutralCheckbox).toHaveClass(
-    "[&[data-state='checked']]:bg_bgSolid.neutral",
+    "[&[data-checked='true']]:bg_bgSolid.neutral",
   );
   expect(dangerCheckbox).toHaveClass(
-    "[&[data-state='checked']]:bg_bgSolid.danger",
+    "[&[data-checked='true']]:bg_bgSolid.danger",
   );
   expect(warningCheckbox).toHaveClass(
-    "[&[data-state='checked']]:bg_bgSolid.warning",
+    "[&[data-checked='true']]:bg_bgSolid.warning",
   );
   expect(successCheckbox).toHaveClass(
-    "[&[data-state='checked']]:bg_bgSolid.success",
+    "[&[data-checked='true']]:bg_bgSolid.success",
   );
-  expect(infoCheckbox).toHaveClass("[&[data-state='checked']]:bg_bgSolid.info");
+  expect(infoCheckbox).toHaveClass("[&[data-checked='true']]:bg_bgSolid.info");
 });
 
 test("체크된 상태와 체크되지않은 상태가 올바르게 렌더링됨", () => {
@@ -65,8 +65,8 @@ test("체크된 상태와 체크되지않은 상태가 올바르게 렌더링됨
   const checkedCheckbox = screen.getByLabelText("체크된 상태");
   const uncheckedCheckbox = screen.getByLabelText("체크되지 않은 상태");
 
-  expect(checkedCheckbox).toHaveAttribute("data-state", "checked");
-  expect(uncheckedCheckbox).toHaveAttribute("data-state", "unchecked");
+  expect(checkedCheckbox).toHaveAttribute("data-checked", "true");
+  expect(uncheckedCheckbox).toHaveAttribute("data-checked", "false");
 });
 
 test("disabled 속성이 올바르게 적용됨", () => {
@@ -83,10 +83,10 @@ test("disabled 속성이 올바르게 적용됨", () => {
   expect(enabledCheckbox).not.toBeDisabled();
 
   expect(disabledCheckedCheckbox).toHaveClass(
-    "[&[data-state='checked']]:bg_bg.neutral.disabled!",
+    "[&[data-checked='true']]:bg_bg.neutral.disabled!",
   );
   expect(disabledCheckedCheckbox).toHaveClass(
-    "[&[data-state='checked']]:bd-c_bg.neutral.disabled!",
+    "[&[data-checked='true']]:bd-c_bg.neutral.disabled!",
   );
   expect(disabledUncheckedCheckbox).toHaveClass(
     "[&:disabled]:bd-c_border.neutral.disabled",
@@ -123,7 +123,7 @@ test("체크박스 클릭 시, onChange 핸들러가 호출됨", async () => {
   const checkbox = screen.getByLabelText("테스트 체크박스");
 
   // Initially unchecked
-  expect(checkbox).toHaveAttribute("data-state", "unchecked");
+  expect(checkbox).toHaveAttribute("data-checked", "false");
 
   // Click to check
   await user.click(checkbox);
@@ -176,15 +176,15 @@ test("체크박스가 클릭될 때 체크 상태가 전환됨", async () => {
   const checkbox = screen.getByLabelText("기본 체크박스");
 
   // Initially unchecked
-  expect(checkbox).toHaveAttribute("data-state", "unchecked");
+  expect(checkbox).toHaveAttribute("data-checked", "false");
 
   // Click to check
   await user.click(checkbox);
-  expect(checkbox).toHaveAttribute("data-state", "checked");
+  expect(checkbox).toHaveAttribute("data-checked", "true");
 
   // Click again to uncheck
   await user.click(checkbox);
-  expect(checkbox).toHaveAttribute("data-state", "unchecked");
+  expect(checkbox).toHaveAttribute("data-checked", "false");
 });
 
 test("required 속성값이 true일 경우, label에 별표가 추가됨", () => {

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,6 +1,11 @@
-import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Checkbox as BaseCheckbox } from "@base-ui-components/react/checkbox";
 import { Check } from "lucide-react";
-import React, { type ButtonHTMLAttributes } from "react";
+import React, {
+  type ButtonHTMLAttributes,
+  useCallback,
+  useId,
+  useState,
+} from "react";
 import { css, cva } from "../../../styled-system/css";
 import type { Tone } from "../../tokens/colors";
 
@@ -32,6 +37,7 @@ export interface CheckboxProps
  * - `required` 속성을 사용하여 필수 입력 항목으로 지정할 수 있습니다.
  */
 export const Checkbox = ({
+  id: idProp,
   label,
   value,
   tone = "neutral",
@@ -41,31 +47,50 @@ export const Checkbox = ({
   onChange,
   ...rest
 }: CheckboxProps) => {
+  // uncontrolled 모드에서 내부 상태 추적 (data-checked 동기화용)
+  const [internalChecked, setInternalChecked] = useState(checked ?? false);
+
+  const handleCheckedChange = useCallback(
+    (next: boolean) => {
+      // uncontrolled 모드에서 내부 상태 업데이트
+      if (checked === undefined) {
+        setInternalChecked(next);
+      }
+      onChange?.(next, value);
+    },
+    [checked, onChange, value],
+  );
+
+  // 실제 체크 상태: controlled면 checked prop, uncontrolled면 내부 상태
+  const actualChecked = checked !== undefined ? checked : internalChecked;
+
+  // id 관리: 외부에서 전달된 id 우선, 없으면 안정적 id 생성
+  const autoId = useId();
+  const id = idProp ?? `checkbox-${autoId}`;
+
   return (
-    <label
+    <div
       className={css({
         display: "flex",
         alignItems: "center",
         gap: "8",
-        cursor: "pointer",
         color: "fg.neutral",
-        "&:disabled": {
-          cursor: "not-allowed",
-          color: "fg.neutral.disabled",
-        },
       })}
     >
-      <CheckboxPrimitive.Root
+      <BaseCheckbox.Root
+        id={id}
         checked={checked}
-        required={required}
-        onCheckedChange={(checked) => {
-          onChange?.(checked === true, value);
-        }}
         disabled={disabled}
+        required={required}
+        value={value}
+        onCheckedChange={(next) => handleCheckedChange(next as boolean)}
+        data-checked={actualChecked}
         className={styles({ tone, disabled })}
+        aria-required={required ? "true" : undefined}
+        aria-labelledby={`${id}-label`}
         {...rest}
       >
-        <CheckboxPrimitive.Indicator
+        <BaseCheckbox.Indicator
           className={css({
             width: "100%",
             height: "100%",
@@ -75,19 +100,31 @@ export const Checkbox = ({
           })}
         >
           <Check size={16} />
-        </CheckboxPrimitive.Indicator>
-      </CheckboxPrimitive.Root>
-      {label}
-      {required && (
-        <span
-          className={css({
-            color: "fg.danger",
-          })}
-        >
-          *
-        </span>
-      )}
-    </label>
+        </BaseCheckbox.Indicator>
+      </BaseCheckbox.Root>
+      <label
+        id={`${id}-label`}
+        htmlFor={id}
+        className={css({
+          cursor: disabled ? "not-allowed" : "pointer",
+          color: disabled ? "fg.neutral.disabled" : "fg.neutral",
+          display: "flex",
+          alignItems: "center",
+          gap: "4",
+        })}
+      >
+        {label}
+        {required && (
+          <span
+            className={css({
+              color: "fg.danger",
+            })}
+          >
+            *
+          </span>
+        )}
+      </label>
+    </div>
   );
 };
 
@@ -125,42 +162,42 @@ const styles = cva({
   variants: {
     tone: {
       brand: {
-        "&[data-state='checked']": {
+        "&[data-checked='true']": {
           bg: "bgSolid.brand",
           borderColor: "bgSolid.brand",
           color: "fgSolid.brand",
         },
       },
       neutral: {
-        "&[data-state='checked']": {
+        "&[data-checked='true']": {
           bg: "bgSolid.neutral",
           borderColor: "bgSolid.neutral",
           color: "fgSolid.neutral",
         },
       },
       danger: {
-        "&[data-state='checked']": {
+        "&[data-checked='true']": {
           bg: "bgSolid.danger",
           borderColor: "bgSolid.danger",
           color: "fgSolid.danger",
         },
       },
       warning: {
-        "&[data-state='checked']": {
+        "&[data-checked='true']": {
           bg: "bgSolid.warning",
           borderColor: "bgSolid.warning",
           color: "fgSolid.warning",
         },
       },
       success: {
-        "&[data-state='checked']": {
+        "&[data-checked='true']": {
           bg: "bgSolid.success",
           borderColor: "bgSolid.success",
           color: "fgSolid.success",
         },
       },
       info: {
-        "&[data-state='checked']": {
+        "&[data-checked='true']": {
           bg: "bgSolid.info",
           borderColor: "bgSolid.info",
           color: "fgSolid.info",
@@ -169,7 +206,7 @@ const styles = cva({
     },
     disabled: {
       true: {
-        "&[data-state='checked']": {
+        "&[data-checked='true']": {
           bg: "bg.neutral.disabled!",
           borderColor: "bg.neutral.disabled!",
           color: "fg.neutral.disabled!",


### PR DESCRIPTION
# Checkbox Base UI 마이그레이션 POC 노트

## 개요

Radix 기반 `Checkbox` 컴포넌트를 Base UI (`@base-ui-components/react`)로 교체한 POC.

### POC 목표 (Goals)

- 기존 퍼블릭 Props (`label`, `tone`, `checked`, `disabled`, `required`, `value`, `onChange`) API 유지
- 기존 스타일 토큰 및 cva 변이 규칙 변화 최소 (Base UI 기본 `data-checked` 활용)
- 기존 테스트(Vitest) & Storybook 스토리 수정 최소화
- 접근성: 라벨링 / 키보드 / aria-required / 포커스 behavior 회귀 없음
- Base UI 도입 시 발생할 수 있는 상태 관리 경고 제거 및 패턴 확립 (controlled + uncontrolled 동시 지원)
- 리팩터링 후 팀이 추정 가능한 마이그레이션 비용 근거치 확보

### Radix → Base UI 그림으로 보기

```mermaid
flowchart TD
	subgraph Radix
		R1["RadixCheckbox.Root"] --> R2["RadixCheckbox.Indicator"]
	end
	subgraph BaseUI
		B1["BaseCheckbox.Root"] --> B2["BaseCheckbox.Indicator"]
	end
	subgraph Styling
		S1["data-state='checked'<br/>(기존 CSS)"] --> S2["data-checked='true'<br/>(최종)"]
	end
	R1 -->|교체| B1
	R2 -->|교체| B2
	S1 -->|셀렉터 업데이트| S2
```

## 변경 사항 요약

- 의존성: `@base-ui-components/react` 추가, `@radix-ui/react-checkbox` 제거.
- 컴포넌트 내부 구현: `@radix-ui/react-checkbox` → `@base-ui-components/react/checkbox` (`Checkbox.Root`, `Checkbox.Indicator`).
- 라벨 구조: 초기에는 전체를 `<label>`로 감싸 duplicate label issue 발생 → `Checkbox.Root` + 별도 `<label htmlFor>` 구조로 조정, `aria-labelledby` 연결.
- 상태 관리: Radix 시절과 동일 API 유지 (`checked`, `defaultChecked`, `onChange(checked:boolean, value?:string)`). Base UI 경고 제거하면서도 controlled + uncontrolled 동시 지원 패턴(`isControlled` 분기) 확립.
- 스타일: 기존 cva 스타일 재사용. 커스텀 `data-state` 제거하고 Base UI 제공 상태 attribute(`data-checked="true|false"`) 직접 사용하도록 셀렉터 업데이트.

## 테스트 결과

- `src/components/Checkbox/Checkbox.test.tsx` 10개 테스트 모두 통과.

## 접근성

- 버튼 역할(`role="checkbox"`) + hidden input 구조(Base UI 기본) 유지.

## 추정 마이그레이션 비용 (RadixUI 제거 및 BaseUI 교체 시)

| 항목             | 세부 내용                                                     | 순수 개발 | 학습/리스크 버퍼(×1.5) | 합계 추정 |
| ---------------- | ------------------------------------------------------------- | --------- | ---------------------- | --------- |
| 초기 탐색 & 설치 | Base UI 도입, API 파악, 타입/트리셰이킹 확인                  | 0.5h      | 0.25h                  | 0.75h     |
| 구현 교체        | Radix → Base UI 내부 치환, 상태 selector 전환(`data-checked`) | 0.4h      | 0.2h                   | 0.6h      |
| 라벨/접근성 조정 | 중복 라벨 이슈 해결, aria 속성 검증                           | 0.3h      | 0.15h                  | 0.45h     |
| 테스트 회귀 처리 | 실패 케이스 분석 & 수정, 추가 보강                            | 0.3h      | 0.2h                   | 0.5h      |
| 상태 모델 정리   | 경고 제거(Controlled 통일) 패턴 확정                          | 0.2h      | 0.1h                   | 0.3h      |
| 문서(POC 노트)   | 노트 작성, 비용 추정 산출                                     | 0.3h      | 0.1h                   | 0.4h      |
| 예비 버퍼        | 예기치 못한 a11y/빌드/타입 이슈                               | -         | 0.3h                   | 0.3h      |
| 합계             |                                                               | 2.0h      | 1.3h                   | ≈3.3h     |

## 결론

**단순 토글 계열 컴포넌트는 Base UI로 무리 없이 이전 가능.**


## 부록

### 상태 결정 플로우 (Controlled vs Uncontrolled)

```mermaid
flowchart LR
	A[Props 입력] --> B{checked prop 존재?}
	B -- 예(defined) --> C[Controlled 모드\n사용자 제공 checked]
	C --> D[effectiveChecked = props.checked]
	B -- 아니오(undefined) --> E[Uncontrolled 모드\n내부 useState]
	E --> F[effectiveChecked = internal state]
	D --> G[BaseCheckbox.Root checked=effectiveChecked]
	F --> G
	G --> H{onCheckedChange}
	H -->|Controlled| I[onChange callback 만 호출]
	H -->|Uncontrolled| J[내부 state set + onChange]
```
