### PR TITLE
fix: Cannot convert a Symbol value to a string

### DIFF
--- a/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -19,6 +19,11 @@ export default {
       </>
     ),
   },
+  argTypes: {
+    children: {
+      control: false,
+    },
+  },
 } satisfies Meta<typeof RadioGroup>;
 
 type Story = StoryObj<typeof RadioGroup>;


### PR DESCRIPTION
## 변경 사항

스토리북에서 RadioGroup 컴포넌트의 Docs 페이지에서 발생하는 "Cannot convert a Symbol value to a string" 오류를 수정하였습니다.

- Before

<img width="2676" height="1372" alt="2025-08-17 at 07 33 32" src="https://github.com/user-attachments/assets/cf23e767-e255-4e82-86e1-7d04e0e15360" />

- After

<img width="2818" height="1786" alt="2025-08-17 at 07 33 06" src="https://github.com/user-attachments/assets/220dadfa-8aa9-4472-b432-3db040090131" />

## 목적

https://github.com/DaleStudy/daleui/issues/213#issuecomment-3193972056 에서 보고된 문제입니다.