### PR TITLE
TextInput 컴포넌트에서 불필요한 forwardRef 제거

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type ComponentPropsWithoutRef } from "react";
+import { type ComponentPropsWithoutRef, type Ref } from "react";
 import { cva, cx } from "../../../styled-system/css";
 import { Icon, type IconProps } from "../Icon/Icon";
 export interface TextInputProps
@@ -13,6 +13,8 @@ export interface TextInputProps
   trailingIcon?: IconProps["name"];
   /** 플레이스홀더 텍스트 */
   placeholder?: string;
+  /** DOM 요소 참조 */
+  ref?: Ref<HTMLInputElement>;
 }
 
 /**
@@ -20,51 +22,50 @@ export interface TextInputProps
  * - `leadingIcon`과 `trailingIcon` prop을 통해 아이콘을 앞뒤에 추가할 수 있습니다.
  * - `disabled` prop으로 비활성화 상태를 제어할 수 있으며, `state` prop을 통해 'error'와 같은 특정 상태를 표현할 수 있습니다.
  */
-export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
-  (
-    { size, invalid, className, leadingIcon, trailingIcon, disabled, ...rest },
-    ref,
-  ) => {
-    const renderIcon = (name: IconProps["name"]) => {
-      let tone: IconProps["tone"];
+export function TextInput({
+  size,
+  invalid,
+  className,
+  leadingIcon,
+  trailingIcon,
+  disabled,
+  ref,
+  ...rest
+}: TextInputProps) {
+  const renderIcon = (name: IconProps["name"]) => {
+    let tone: IconProps["tone"];
 
-      if (disabled) {
-        tone = "neutral";
-      } else if (invalid) {
-        tone = "danger";
-      }
-
-      return (
-        <Icon
-          name={name}
-          size={size}
-          tone={tone}
-          data-testid={`icon-${name}`}
-        />
-      );
-    };
+    if (disabled) {
+      tone = "neutral";
+    } else if (invalid) {
+      tone = "danger";
+    }
 
     return (
-      <div
-        className={cx(
-          wrapperStyles({ size, state: invalid ? "error" : undefined }),
-          className,
-        )}
-        data-disabled={disabled ? "" : undefined}
-      >
-        {leadingIcon && renderIcon(leadingIcon)}
-        <input
-          className={inputStyles()}
-          ref={ref}
-          disabled={disabled}
-          aria-invalid={invalid ? true : undefined}
-          {...rest}
-        />
-        {trailingIcon && renderIcon(trailingIcon)}
-      </div>
+      <Icon name={name} size={size} tone={tone} data-testid={`icon-${name}`} />
     );
-  },
-);
+  };
+
+  return (
+    <div
+      className={cx(
+        wrapperStyles({ size, state: invalid ? "error" : undefined }),
+        className,
+      )}
+      data-disabled={disabled ? "" : undefined}
+    >
+      {leadingIcon && renderIcon(leadingIcon)}
+      <input
+        className={inputStyles()}
+        ref={ref}
+        disabled={disabled}
+        aria-invalid={invalid ? true : undefined}
+        {...rest}
+      />
+      {trailingIcon && renderIcon(trailingIcon)}
+    </div>
+  );
+}
 
 const wrapperStyles = cva({
   base: {


### PR DESCRIPTION
## 변경 사항
- TextInput 컴포넌트에서 불필요한 `forwardRef` 제거
- 최신 React(19 이상)에서는 일반 props처럼 `ref` 전달이 가능하여 `forwardRef`가 불필요([공식 문서 참고](https://react.dev/learn/manipulating-the-dom-with-refs#accessing-another-components-dom-nodes))

## 목적
- 최신 React 버전에 맞춰 불필요한 코드를 정리
- 불필요한 `forwardRef` 제거로 코드 단순화 및 일관성 확보

## 리뷰어에게
- PasswordInput PR 리뷰 과정에서 forwardRef을 제거하였고 코드 일관성을 위해 TextInput에서도 제거합니다. 자세한 맥락은 [이슈](https://github.com/DaleStudy/daleui/issues/445) 참고부탁드립니다.