### PR TITLE
TextInput 컴포넌트 invalid + hover 시 테두리 색 이슈

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -78,6 +78,14 @@ const wrapperStyles = cva({
     transition: "all 0.2s ease-in-out",
     backgroundColor: "appBg",
 
+    "&:focus-within": {
+      outlineStyle: "solid",
+      outlineWidth: "lg",
+      outlineOffset: "2px",
+      borderRadius: "md",
+      outlineColor: "border.brand.focus",
+    },
+
     "&:has(input:disabled)": {
       cursor: "not-allowed",
       backgroundColor: "bg.neutral.disabled",
@@ -93,7 +101,6 @@ const wrapperStyles = cva({
     invalid: {
       true: {
         border: "danger",
-        "&:focus-within": { borderColor: "border.danger", boxShadow: "none" },
       },
       false: {
         "&:hover": {
@@ -101,9 +108,6 @@ const wrapperStyles = cva({
         },
         "&:active": {
           borderColor: "border.neutral.active",
-        },
-        "&:focus-within": {
-          borderColor: "border.brand.focus",
         },
       },
     },

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -49,10 +49,7 @@ export function TextInput({
 
   return (
     <div
-      className={cx(
-        wrapperStyles({ size, state: invalid ? "error" : undefined }),
-        className,
-      )}
+      className={cx(wrapperStyles({ size, invalid }), className)}
       data-disabled={disabled ? "" : undefined}
     >
       {leadingIcon && renderIcon(leadingIcon)}
@@ -81,15 +78,6 @@ const wrapperStyles = cva({
     transition: "all 0.2s ease-in-out",
     backgroundColor: "appBg",
 
-    "&:hover": {
-      borderColor: "border.neutral.hover",
-    },
-    "&:active": {
-      borderColor: "border.neutral.active",
-    },
-    "&:focus-within": {
-      borderColor: "border.brand.focus",
-    },
     "&:has(input:disabled)": {
       cursor: "not-allowed",
       backgroundColor: "bg.neutral.disabled",
@@ -102,10 +90,21 @@ const wrapperStyles = cva({
       md: { h: "48px", px: "12", fontSize: "md" },
       lg: { h: "56px", px: "24", fontSize: "lg" },
     },
-    state: {
-      error: {
+    invalid: {
+      true: {
         border: "danger",
         "&:focus-within": { borderColor: "border.danger", boxShadow: "none" },
+      },
+      false: {
+        "&:hover": {
+          borderColor: "border.neutral.hover",
+        },
+        "&:active": {
+          borderColor: "border.neutral.active",
+        },
+        "&:focus-within": {
+          borderColor: "border.brand.focus",
+        },
       },
     },
   },


### PR DESCRIPTION
## 변경 사항

<!-- 무엇을 변경했나요? (예: 새 컴포넌트 추가, 디자인 수정, 문서 업데이트) -->

- invalid 상태일때 hover시 border 색상이 변경되는 버그 발생하여 스타일 수정

## 목적

<!-- 왜 이 변경이 필요한가요? (예: 접근성 개선, 사용자 경험 향상) -->

- figma 디자인에서는 invalid 상태일때 hover시 색상 변경이 없으며 token또한 danger에 hover상태가 없습니다. 따라서 잘못된 스타일 적용입니다.

## 리뷰어에게

<!-- 특별히 확인해 주셨으면 하는 부분이 있나요? (예: 호버 상태, 모바일 뷰포트) -->

[screen-capture (1).webm](https://github.com/user-attachments/assets/bf503a87-3807-42de-ba43-420d4764a71e)

