### PR TITLE
PasswordInput focus 시 border-radius 깜빡임 및 placeholder 텍스트 수정

### DIFF
--- a/src/components/PasswordInput/PasswordInput.tsx
+++ b/src/components/PasswordInput/PasswordInput.tsx
@@ -4,7 +4,7 @@ import { Icon } from "../Icon/Icon";
 
 export interface PasswordInputProps
   extends Omit<ComponentPropsWithoutRef<"input">, "size" | "type"> {
-  /** 입력 안내 텍스트 */
+  /** 플레이스홀더 */
   placeholder?: string;
   /** 컨트롤 크기 */
   size?: "sm" | "md" | "lg";
@@ -91,7 +91,6 @@ const containerStyles = cva({
       outlineWidth: "lg",
       outlineColor: "border.brand.focus",
       outlineOffset: "2px",
-      borderRadius: "md",
     },
     "&:has(input:disabled)": {
       cursor: "not-allowed",


### PR DESCRIPTION
## 변경 사항

- PasswordInput 컴포넌트 focus 시 border-radius 꿀렁이는 문제 수정([이슈 티켓](https://github.com/DaleStudy/daleui/issues/481))
- placeholder 텍스트 간단히 수정(입력안내텍스트 -> 플레이스홀더)

## 목적

- 버그 해결 및 플레이스홀더 텍스트 문구 명확화

## 리뷰어에게

- focus 시 border-radius 움직이던 이슈 이제 정상 동작되는지 확인 부탁드립니다.