### PR TITLE
PasswordInput/TextInput size 속성 제거

### DIFF
--- a/src/components/PasswordInput/PasswordInput.stories.tsx
+++ b/src/components/PasswordInput/PasswordInput.stories.tsx
@@ -12,15 +12,8 @@ export default {
   },
   args: {
     placeholder: "패스워드를 입력해주세요.",
-    size: "md",
     disabled: false,
     invalid: false,
-  },
-  argTypes: {
-    size: {
-      control: "select",
-      description: "입력 필드의 크기",
-    },
   },
 } satisfies Meta<typeof PasswordInput>;
 

--- a/src/components/PasswordInput/PasswordInput.tsx
+++ b/src/components/PasswordInput/PasswordInput.tsx
@@ -6,8 +6,6 @@ export interface PasswordInputProps
   extends Omit<ComponentPropsWithoutRef<"input">, "size" | "type"> {
   /** 플레이스홀더 */
   placeholder?: string;
-  /** 컨트롤 크기 */
-  size?: "sm" | "md" | "lg";
   /** 오류 상태 여부 (true면 위험 톤 적용 및 aria-invalid=true) */
   invalid?: boolean;
   /** 비활성화 여부 */
@@ -18,11 +16,10 @@ export interface PasswordInputProps
 
 /**
  * - 패스워드 입력 컴포넌트입니다. 우측 아이콘으로 비밀번호 가시성을 토글할 수 있습니다.
- * - `size`(sm/md/lg), `invalid`, `disabled` prop으로 상태를 제어할 수 있습니다.
+ * - `invalid`, `disabled` prop으로 상태를 제어할 수 있습니다.
  * - 토글 버튼은 키보드 접근성과 스크린 리더를 지원합니다.
  */
 export function PasswordInput({
-  size = "md",
   invalid = false,
   disabled = false,
   placeholder = "패스워드를 입력해주세요.",
@@ -40,7 +37,6 @@ export function PasswordInput({
   return (
     <div
       className={containerStyles({
-        size,
         state: invalid ? "error" : undefined,
       })}
     >
@@ -49,7 +45,7 @@ export function PasswordInput({
         type={isVisible ? "text" : "password"}
         placeholder={placeholder}
         disabled={disabled}
-        className={inputStyles({ size })}
+        className={inputStyles()}
         aria-label="패스워드"
         aria-invalid={invalid ? true : undefined}
         {...rest}
@@ -62,7 +58,7 @@ export function PasswordInput({
         aria-pressed={isVisible}
         aria-label={isVisible ? "패스워드 숨기기" : "패스워드 보기"}
       >
-        <Icon name={isVisible ? "eye" : "eyeOff"} size={size} tone="neutral" />
+        <Icon name={isVisible ? "eye" : "eyeOff"} size="md" tone="neutral" />
       </button>
     </div>
   );
@@ -74,6 +70,9 @@ const containerStyles = cva({
     display: "flex",
     alignItems: "center",
     width: "100%",
+    height: "12",
+    paddingX: "12",
+    gap: "8",
     borderWidth: "md",
     borderStyle: "solid",
     borderRadius: "sm",
@@ -102,11 +101,6 @@ const containerStyles = cva({
     },
   },
   variants: {
-    size: {
-      sm: { height: "8", paddingX: "12", gap: "8" },
-      md: { height: "10", paddingX: "12", gap: "8" },
-      lg: { height: "12", paddingX: "12", gap: "8" },
-    },
     state: {
       error: {
         borderColor: "border.danger",
@@ -122,9 +116,6 @@ const containerStyles = cva({
       },
     },
   },
-  defaultVariants: {
-    size: "md",
-  },
 });
 
 const inputStyles = cva({
@@ -133,7 +124,7 @@ const inputStyles = cva({
     border: "none",
     outline: "none",
     color: "fg.neutral.default",
-    fontSize: "sm",
+    fontSize: "md",
     fontWeight: "medium",
     lineHeight: "tight",
     letterSpacing: "balanced",
@@ -147,13 +138,6 @@ const inputStyles = cva({
       "&::placeholder": {
         color: "fg.neutral.disabled",
       },
-    },
-  },
-  variants: {
-    size: {
-      sm: { fontSize: "xs" },
-      md: { fontSize: "sm" },
-      lg: { fontSize: "md" },
     },
   },
 });

--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -15,45 +15,17 @@ export default {
   },
   args: {
     placeholder: "텍스트를 입력해주세요.",
-    size: "md",
     disabled: false,
     invalid: false,
-  },
-  argTypes: {
-    size: {
-      control: "select",
-      description: "입력 필드의 크기",
-    },
   },
 } satisfies Meta<typeof TextInput>;
 
 type Story = StoryObj<typeof TextInput>;
 
 /**
- * 가장 기본적인 TextInput 컴포넌트입니다. `size`, `disabled`, `invalid` 등의 props를 조절해보세요.
+ * 가장 기본적인 TextInput 컴포넌트입니다. `disabled`, `invalid` 등의 props를 조절해보세요.
  */
 export const Default: Story = {};
-
-/**
- * `size` prop을 통해 입력 필드의 크기를 조절할 수 있습니다.
- */
-export const Sizes: Story = {
-  render: (args) => (
-    <div className={vstack({ gap: "16", w: "320px" })}>
-      <TextInput {...args} size="sm" placeholder="Small size" />
-      <TextInput {...args} size="md" placeholder="Medium size" />
-      <TextInput {...args} size="lg" placeholder="Large size" />
-    </div>
-  ),
-  argTypes: {
-    size: {
-      control: false,
-    },
-    placeholder: {
-      control: false,
-    },
-  },
-};
 
 /**
  * `leadingIcon`과 `trailingIcon` prop에 아이콘 이름을 문자열로 전달하여 아이콘을 표시할 수 있습니다.
@@ -188,7 +160,6 @@ const ControlledTextInput = () => {
 export const Controlled: Story = {
   render: () => <ControlledTextInput />,
   argTypes: {
-    size: { control: false },
     invalid: { control: false },
     disabled: { control: false },
     placeholder: { control: false },

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -3,8 +3,6 @@ import { cva, cx } from "../../../styled-system/css";
 import { Icon, type IconProps } from "../Icon/Icon";
 export interface TextInputProps
   extends Omit<ComponentPropsWithoutRef<"input">, "size"> {
-  /** 크기 */
-  size?: "sm" | "md" | "lg";
   /** 오류 상태 여부 (true일 경우 danger 색상으로 표시됩니다) */
   invalid?: boolean;
   /** 앞쪽 아이콘 이름 (아이콘 컴포넌트의 name 속성에 해당) */
@@ -24,7 +22,6 @@ export interface TextInputProps
  * - `disabled` prop으로 비활성화 상태를 제어할 수 있으며, `state` prop을 통해 'error'와 같은 특정 상태를 표현할 수 있습니다.
  */
 export function TextInput({
-  size,
   invalid,
   className,
   leadingIcon,
@@ -43,13 +40,13 @@ export function TextInput({
     }
 
     return (
-      <Icon name={name} size={size} tone={tone} data-testid={`icon-${name}`} />
+      <Icon name={name} size="md" tone={tone} data-testid={`icon-${name}`} />
     );
   };
 
   return (
     <div
-      className={cx(wrapperStyles({ size, invalid }), className)}
+      className={cx(wrapperStyles({ invalid }), className)}
       data-disabled={disabled ? "" : undefined}
     >
       {leadingIcon && renderIcon(leadingIcon)}
@@ -71,6 +68,9 @@ const wrapperStyles = cva({
     alignItems: "center",
     gap: "8",
     width: "100%",
+    height: "12",
+    paddingX: "12",
+    fontSize: "md",
     position: "relative",
     border: "neutral",
     borderWidth: "md",
@@ -93,11 +93,6 @@ const wrapperStyles = cva({
     },
   },
   variants: {
-    size: {
-      sm: { h: "40px", px: "16", fontSize: "sm" },
-      md: { h: "48px", px: "12", fontSize: "md" },
-      lg: { h: "56px", px: "24", fontSize: "lg" },
-    },
     invalid: {
       true: {
         border: "danger",
@@ -111,9 +106,6 @@ const wrapperStyles = cva({
         },
       },
     },
-  },
-  defaultVariants: {
-    size: "md",
   },
 });
 


### PR DESCRIPTION
## 변경 사항
- PasswordInput, TextInput 컴포넌트에서 size prop 제거
- height는 CSS 스타일링으로만 관리되도록 수정

## 목적
- Figma 컴포넌트에 존재하지 않는 속성(size)을 제거하여 디자인과 구현 불일치 해소
- 컴포넌트 API를 Figma와 align 시켜 혼동 방지 및 일관성 유지

## 리뷰어에게
- 스토리북에서도 잘 제거되었는지 같이 더블체크 부탁드립니다.
