### PR TITLE
디펜더봇 쿨다운 설정

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 14
     groups:
       storybook:
         patterns:


### PR DESCRIPTION
## 변경 사항

디펜더봇에 추가된 [쿨다운](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-) 설정을 적용하여 2주일 정도 기다렸다가 의존성을 업데이트하도록 합니다.

## 목적

Vite나 Vitest처럼 개발이 아주 활성한 프로젝트에서 패치가 일어날 때 마다 우리 저장소에 디펜더봇 PR이 생기는 것을 좀 완화하기 위한 목적입니다. 2주 정도 늦게 업데이트 해도 평균과 비교해봤을 때 여전히 아주 빠른 업데이트일 것입니다.