### PR TITLE
디펜더봇 크로메틱 예외

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pre-chromatic:
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    if: (github.event_name == 'push' || github.event.pull_request.draft == false) && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - id: gen_url
@@ -21,7 +21,7 @@ jobs:
       url: ${{ steps.gen_url.outputs.url }}
 
   chromatic:
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    if: (github.event_name == 'push' || github.event.pull_request.draft == false) && github.actor != 'dependabot[bot]'
     environment:
       name: chromatic
       url: ${{ needs.pre-chromatic.outputs.url }}


### PR DESCRIPTION
## 변경 사항

디펜더봇 PR에서 컴포넌트가 스토리를 업데이트할 가능성은 거의 없으므로 크로메틱이 자동으로 돌지 않도록 설정합니다.

## 목적

불필요한 스냅샷을 최소화하여 크로메틱 사용량을 아끼기 위함입니다.

## 리뷰어에게