### PR TITLE
button 컴포넌트에 tone & variant 적용

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -43,10 +43,10 @@ export const Tone: StoryObj<typeof Button> = {
           브랜드 버튼
         </Button>
         <Button {...args} tone="neutral">
-          뉴트럴 버튼
+          중립 버튼
         </Button>
         <Button {...args} tone="danger">
-          데인저 버튼
+          위험 버튼
         </Button>
       </div>
     );

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -9,102 +9,58 @@ test("텍스트와 함께 버튼이 올바르게 렌더링됨", () => {
   expect(screen.getByText("테스트")).toBeInTheDocument();
 });
 
-test("variant 속성이 올바르게 적용됨", () => {
-  render(
-    <>
-      <Button variant="solid">솔리드 버튼</Button>
-      <Button variant="outline">아웃라인 버튼</Button>
-      <Button variant="ghost">고스트 버튼</Button>
-    </>,
-  );
+const toneAndVariantCases = [
+  {
+    case: "solid - brand",
+    props: { variant: "solid", tone: "brand" },
+    expectedClass: "bg_bgSolid.brand",
+  },
+  {
+    case: "solid - neutral",
+    props: { variant: "solid", tone: "neutral" },
+    expectedClass: "bg_bgSolid.neutral",
+  },
+  {
+    case: "solid - danger",
+    props: { variant: "solid", tone: "danger" },
+    expectedClass: "bg_bgSolid.danger",
+  },
+  {
+    case: "outline - brand",
+    props: { variant: "outline", tone: "brand" },
+    expectedClass: "bd_brand",
+  },
+  {
+    case: "outline - neutral",
+    props: { variant: "outline", tone: "neutral" },
+    expectedClass: "bd_neutral",
+  },
+  {
+    case: "outline - danger",
+    props: { variant: "outline", tone: "danger" },
+    expectedClass: "bd_danger",
+  },
+  {
+    case: "ghost - brand",
+    props: { variant: "ghost", tone: "brand" },
+    expectedClass: "c_fg.brand",
+  },
+  {
+    case: "ghost - neutral",
+    props: { variant: "ghost", tone: "neutral" },
+    expectedClass: "c_fg.neutral",
+  },
+  {
+    case: "ghost - danger",
+    props: { variant: "ghost", tone: "danger" },
+    expectedClass: "c_fg.danger",
+  },
+] as const;
 
-  expect(screen.getByRole("button", { name: "솔리드 버튼" })).toHaveClass(
-    "bg_bgSolid.brand",
-  );
-  expect(screen.getByRole("button", { name: "아웃라인 버튼" })).toHaveClass(
-    "bd_brand bd-w_lg",
-  );
-  expect(screen.getByRole("button", { name: "고스트 버튼" })).toHaveClass(
-    "bg_transparent bd_none",
-  );
-});
-
-test("tone 속성이 올바르게 적용됨", () => {
-  render(
-    <>
-      <Button variant="solid" tone="brand">
-        솔리드 브랜드
-      </Button>
-      <Button variant="outline" tone="brand">
-        아웃라인 브랜드
-      </Button>
-      <Button variant="ghost" tone="brand">
-        고스트 브랜드
-      </Button>
-      <Button variant="solid" tone="neutral">
-        솔리드 중립
-      </Button>
-      <Button variant="outline" tone="neutral">
-        아웃라인 중립
-      </Button>
-      <Button variant="ghost" tone="neutral">
-        고스트 중립
-      </Button>
-      <Button variant="solid" tone="danger">
-        솔리드 위험
-      </Button>
-      <Button variant="outline" tone="danger">
-        아웃라인 위험
-      </Button>
-      <Button variant="ghost" tone="danger">
-        고스트 위험
-      </Button>
-    </>,
-  );
-
-  // solid는 brand tone을 지원
-  expect(screen.getByRole("button", { name: "솔리드 브랜드" })).toHaveClass(
-    "bg_bgSolid.brand",
-  );
-
-  // solid는 neutral tone을 지원
-  expect(screen.getByRole("button", { name: "솔리드 중립" })).toHaveClass(
-    "bg_bgSolid.neutral",
-  );
-
-  // solid는 danger tone을 지원
-  expect(screen.getByRole("button", { name: "솔리드 위험" })).toHaveClass(
-    "bg_bgSolid.danger",
-  );
-
-  // outline은 brand tone을 지원
-  expect(screen.getByRole("button", { name: "아웃라인 브랜드" })).toHaveClass(
-    "bd_brand",
-  );
-
-  // outline은 neutral tone을 지원
-  expect(screen.getByRole("button", { name: "아웃라인 중립" })).toHaveClass(
-    "bd_neutral",
-  );
-
-  // outline은 danger tone을 지원
-  expect(screen.getByRole("button", { name: "아웃라인 위험" })).toHaveClass(
-    "bd_danger",
-  );
-
-  // ghost는 brand tone을 지원
-  expect(screen.getByRole("button", { name: "고스트 브랜드" })).toHaveClass(
-    "c_fg.brand",
-  );
-
-  // ghost는 neutral tone을 지원
-  expect(screen.getByRole("button", { name: "고스트 중립" })).toHaveClass(
-    "c_fg.neutral",
-  );
-
-  // ghost는 danger tone을 지원
-  expect(screen.getByRole("button", { name: "고스트 위험" })).toHaveClass(
-    "c_fg.danger",
+test.each(toneAndVariantCases)("$case가 적용됨", ({ props, expectedClass }) => {
+  render(<Button {...props}>버튼 테스트</Button>);
+  expect(screen.getByRole("button", { name: "버튼 테스트" })).toHaveClass(
+    expectedClass,
   );
 });
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -7,7 +7,7 @@ import { type IconName } from "../../tokens/iconography";
 type size = "sm" | "md" | "lg";
 
 /** 공통 버튼 속성 */
-interface BaseButtonProps
+export interface ButtonProps
   extends Omit<HTMLAttributes<HTMLButtonElement>, "style"> {
   /** 버튼 텍스트 */
   children: string;
@@ -31,8 +31,6 @@ interface BaseButtonProps
   /** 버튼의 스타일 종류 */
   variant?: "solid" | "outline" | "ghost";
 }
-
-export type ButtonProps = BaseButtonProps;
 
 /**
  * - `variant` 속성으로 버튼의 스타일 종류를 지정할 수 있습니다.
@@ -152,7 +150,7 @@ const styles = cva({
     },
     "&:focus-visible": {
       outlineStyle: "solid",
-      outlineWidth: "lg",
+      outlineWidth: "sm",
       outlineOffset: "3px",
     },
   },
@@ -202,7 +200,6 @@ const styles = cva({
     },
   },
   compoundVariants: [
-    // solid (brand)
     {
       variant: "solid",
       tone: "brand",
@@ -217,7 +214,6 @@ const styles = cva({
         },
       },
     },
-    // solid(neutral)
     {
       variant: "solid",
       tone: "neutral",
@@ -232,7 +228,6 @@ const styles = cva({
         },
       },
     },
-    // solid (danger)
     {
       variant: "solid",
       tone: "danger",
@@ -247,13 +242,12 @@ const styles = cva({
         },
       },
     },
-    // outline (brand)
     {
       variant: "outline",
       tone: "brand",
       css: {
         border: "brand",
-        borderWidth: "lg",
+        borderWidth: "sm",
         color: "fg.brand",
         "&:hover": {
           color: "fg.brand.hover",
@@ -265,13 +259,12 @@ const styles = cva({
         },
       },
     },
-    // outline (neutral)
     {
       variant: "outline",
       tone: "neutral",
       css: {
         border: "neutral",
-        borderWidth: "lg",
+        borderWidth: "sm",
         color: "fg.neutral",
         "&:hover": {
           color: "fg.neutral.hover",
@@ -283,13 +276,12 @@ const styles = cva({
         },
       },
     },
-    // outline (danger)
     {
       variant: "outline",
       tone: "danger",
       css: {
         border: "danger",
-        borderWidth: "lg",
+        borderWidth: "sm",
         color: "fg.danger",
         "&:hover": {
           color: "fg.danger.hover",
@@ -322,7 +314,6 @@ const styles = cva({
         px: "0.9rem",
       },
     },
-    // ghost
     {
       variant: "ghost",
       tone: "brand",
@@ -368,7 +359,6 @@ const styles = cva({
         },
       },
     },
-    // disabled
     {
       disabled: true,
       css: {
@@ -398,7 +388,7 @@ const styles = cva({
       tone: "danger",
       css: {
         "&:focus-visible": {
-          outlineColor: "border.danger.focus",
+          outlineColor: "border.danger",
         },
       },
     },


### PR DESCRIPTION
<!-- PR에 대해 알아야 하는 내용은 위키의 컨벤션을 확인해 주세요.
위키 - https://github.com/DaleStudy/daleui/wiki/Conventions -->

## 변경 사항

<!-- 무엇을 변경했나요? (예: 새 컴포넌트 추가, 디자인 수정, 문서 업데이트) -->

- button에 디자인 적용 및 기존 디자인(hover 및 active) 수정

## 목적

<!-- 왜 이 변경이 필요한가요? (예: 접근성 개선, 사용자 경험 향상) -->

- 다얀한 tone에 대한 variant 디자인 적용 필요

## 리뷰어에게

<!-- 특별히 확인해 주셨으면 하는 부분이 있나요? (예: 호버 상태, 모바일 뷰포트) -->

- 호버 및 active 상태에 대한 디자인 가독성(인식이 용이한가)

(몇 가지 부차적인 질문)
~~- UI Review와 UI Tests를 진행한 적은 없는데 이미 통과되어 있는 이유는 뭔지 잘 모르겠습니다...~~ <- draft라서 그랬나봐요.
~~- 추가로 PR을 오픈하고 나서 생각이 났는데 Test 코드도 작성했어야 했던 거죠...?~~
- 테스트 코드에서 tone과 variant에 대한 체크를 각자 시켜야 하는 건 알겠는데 분리를 어떻게 시켜야 하는지 잘 모르겠어요. Tone에 대한 테스트는 대표 Variant인 Solid만 쓰고 Variant에 대한 테스트는 대표 Tone인 Brand만 쓰는 건가 싶기도 하고... 결국 둘이 합쳐져야 하나? 싶기도 하고... 의견 주시면 좋겠습니다.

## PR 작성자 체크 리스트

- [x] UI Review를 요청하고 검토를 받았나요?
- [x] UI Tests를 진행했나요?


<!-- UI Review 및 UI Tests에 대한 내용은 상단 컨벤션 문서의 '7. PR리뷰 및 병합' 내용을 참고해 주세요. -->
