### PR TITLE
Storybook 기반 테스트 제거 및 독립 작성 적용(Card 컴포넌트)

### DIFF
--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -1,15 +1,21 @@
-import { composeStories } from "@storybook/react-vite";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, test, vi } from "vitest";
 import { Card } from "./Card";
-import * as stories from "./Card.stories";
-
-const { Basic, WithLink, WithExternalLink } = composeStories(stories);
 
 describe("Card 렌더링", () => {
   test("기본 Card가 올바르게 렌더링됨", () => {
-    render(<Basic />);
+    render(
+      <Card>
+        <Card.Icon name="star" />
+        <Card.Body>
+          <Card.Title>제목</Card.Title>
+          <Card.Description>
+            이 기능에 대한 설명을 여기에 작성합니다
+          </Card.Description>
+        </Card.Body>
+      </Card>,
+    );
 
     expect(screen.getByText("제목")).toBeInTheDocument();
     expect(
@@ -33,7 +39,17 @@ describe("Card 렌더링", () => {
   });
 
   test("제목이 올바른 스타일로 렌더링됨", () => {
-    render(<Basic />);
+    render(
+      <Card>
+        <Card.Icon name="star" />
+        <Card.Body>
+          <Card.Title>제목</Card.Title>
+          <Card.Description>
+            이 기능에 대한 설명을 여기에 작성합니다
+          </Card.Description>
+        </Card.Body>
+      </Card>,
+    );
 
     const title = screen.getByText("제목");
     expect(title).toHaveClass("fs_lg");
@@ -41,7 +57,17 @@ describe("Card 렌더링", () => {
   });
 
   test("설명이 올바른 스타일로 렌더링됨", () => {
-    render(<Basic />);
+    render(
+      <Card>
+        <Card.Icon name="star" />
+        <Card.Body>
+          <Card.Title>제목</Card.Title>
+          <Card.Description>
+            이 기능에 대한 설명을 여기에 작성합니다
+          </Card.Description>
+        </Card.Body>
+      </Card>,
+    );
 
     const description = screen.getByText(
       "이 기능에 대한 설명을 여기에 작성합니다",
@@ -106,7 +132,16 @@ describe("Card 스타일 속성", () => {
 
 describe("Card 링크", () => {
   test("링크가 올바르게 렌더링됨", () => {
-    render(<WithLink />);
+    render(
+      <Card>
+        <Card.Icon name="info" />
+        <Card.Body>
+          <Card.Title>링크 있는 카드</Card.Title>
+          <Card.Description>링크가 포함된 Card입니다.</Card.Description>
+        </Card.Body>
+        <Card.Link href="#">자세히 보기</Card.Link>
+      </Card>,
+    );
 
     const link = screen.getByRole("link", { name: /자세히 보기/ });
     expect(link).toBeInTheDocument();
@@ -114,7 +149,20 @@ describe("Card 링크", () => {
   });
 
   test("외부 링크가 올바르게 렌더링됨", () => {
-    render(<WithExternalLink />);
+    render(
+      <Card>
+        <Card.Icon name="externalLink" />
+        <Card.Body>
+          <Card.Title>외부 링크 카드</Card.Title>
+          <Card.Description>
+            외부 사이트로 이동하는 링크입니다. 새 탭에서 열립니다.
+          </Card.Description>
+        </Card.Body>
+        <Card.Link href="https://www.example.com" external>
+          외부 사이트 방문
+        </Card.Link>
+      </Card>,
+    );
 
     const externalLink = screen.getByRole("link", {
       name: /외부 사이트 방문/,
@@ -126,14 +174,33 @@ describe("Card 링크", () => {
   });
 
   test("링크의 tone이 올바르게 적용됨", () => {
-    render(<WithLink />);
+    render(
+      <Card>
+        <Card.Icon name="info" />
+        <Card.Body>
+          <Card.Title>링크 있는 카드</Card.Title>
+          <Card.Description>링크가 포함된 Card입니다.</Card.Description>
+        </Card.Body>
+        <Card.Link href="#">자세히 보기</Card.Link>
+      </Card>,
+    );
 
     const link = screen.getByRole("link", { name: /자세히 보기/ });
     expect(link).toHaveClass("c_fg.neutral");
   });
 
   test("링크가 없을 때는 표시되지 않음", () => {
-    render(<Basic />);
+    render(
+      <Card>
+        <Card.Icon name="star" />
+        <Card.Body>
+          <Card.Title>제목</Card.Title>
+          <Card.Description>
+            이 기능에 대한 설명을 여기에 작성합니다
+          </Card.Description>
+        </Card.Body>
+      </Card>,
+    );
 
     expect(screen.queryByRole("link")).not.toBeInTheDocument();
   });
@@ -142,7 +209,16 @@ describe("Card 링크", () => {
 describe("Card 접근성", () => {
   test("Tab 키로 링크에 포커스할 수 있음", async () => {
     const user = userEvent.setup();
-    render(<WithLink />);
+    render(
+      <Card>
+        <Card.Icon name="info" />
+        <Card.Body>
+          <Card.Title>링크 있는 카드</Card.Title>
+          <Card.Description>링크가 포함된 Card입니다.</Card.Description>
+        </Card.Body>
+        <Card.Link href="#">자세히 보기</Card.Link>
+      </Card>,
+    );
 
     const link = screen.getByRole("link", { name: /자세히 보기/ });
 


### PR DESCRIPTION
<!-- PR에 대해 알아야 하는 내용은 위키의 컨벤션을 확인해 주세요.
위키 - https://github.com/DaleStudy/daleui/wiki/Conventions -->

## 변경 사항

- 지난번 #594 티켓의 후속 작업입니다. 마케팅 페이지 테스트 파일에는 다 적용되었지만, 여전히 composeStories를 사용중인 Card컴포넌트가 하나 남아서 Card 컴포넌트 테스트에서 Storybook 기반 테스트(composeStories) 제거하였습니다.
- composeStories 함수 사용처 모두 제거되었고 현재 코드베이스 내 사용처 없습니다.

## 목적

- `composeStories`는 `@storybook/react-vite` 패키지에서 제공하는 함수이므로 현재 스토리 파일에서 `Meta`, `StoryObj` 타입을 import하여 사용 중이기에 패키지를 제거하지는 않았습니다.
- 하지만, 테스트에서 `composeStories` 함수 사용 의존성은 완전히 제거하였습니다.

## 리뷰어에게

- 테스트가 기존 스토리에 의존하지 않고 정상적으로 동작하는지 확인 부탁드립니다.

## PR 작성자 체크 리스트

- [ ] UI Review를 요청하고 검토를 받았나요?
- [ ] UI Tests를 진행했나요?

<!-- UI Review 및 UI Tests에 대한 내용은 상단 컨벤션 문서의 '7. PR리뷰 및 병합' 내용을 참고해 주세요. -->
