### PR TITLE
릴리즈 발행시 동작하는 배포 워크플로우 생성

### DIFF
--- a/.github/workflows/publication.yml
+++ b/.github/workflows/publication.yml
@@ -1,4 +1,4 @@
-name: Npm Publish
+name: Publication 📦
 
 on:
   release:
@@ -10,9 +10,8 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           ref: ${{ github.event.release.tag_name }}
 
       - name: Setup Bun
@@ -21,17 +20,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
-
       - name: Verify tag matches package.json
         run: |
           TAG_NAME="${{ github.event.release.tag_name }}"
           TAG_VERSION="${TAG_NAME#v}"
-          PKG_VERSION=$(node -p "require('./package.json').version")
+          PKG_VERSION=$(jq -r .version package.json)
 
           if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
             echo "Error: 태그 버전과 package.json 버전이 일치하지 않습니다."
@@ -44,20 +37,13 @@ jobs:
       - name: Build package
         run: |
           bun run prepare
-          bun run build
+          bun run build:lib
 
       - name: Publish to npm
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          if [ -z "${NODE_AUTH_TOKEN}" ]; then
-            echo "Error: NPM_TOKEN이 설정되지 않았습니다."
-            exit 1
-          fi
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
 
-          TAG_NAME="${{ github.event.release.tag_name }}"
-          VERSION=${TAG_NAME#v}
-          echo "버전 ${VERSION} 배포를 시작합니다..."
-
-          npm publish --access public
+          bun publish
           echo "npm 배포가 완료되었습니다."


### PR DESCRIPTION
<!-- PR에 대해 알아야 하는 내용은 위키의 컨벤션을 확인해 주세요.
위키 - https://github.com/DaleStudy/daleui/wiki/Conventions -->

## 변경 사항

<!-- 무엇을 변경했나요? (예: 새 컴포넌트 추가, 디자인 수정, 문서 업데이트) -->

- 릴리즈 발행 → 빌드 → npm 배포 프로세스 자동화

## 목적

<!-- 왜 이 변경이 필요한가요? (예: 접근성 개선, 사용자 경험 향상) -->

- 릴리즈 발행시 NPM에 패키지 배포

## 테스트
- act를 이용한 로컬 테스트
- 동일한 워크플로우 파일을 사용하는 [데모 프로젝트](https://github.com/HowToBeAHappyBoy/npm-test)에서 테스트
  - [태그와 packages.json의 버전이 다를 시 에러가 발생하는 케이스](https://github.com/HowToBeAHappyBoy/npm-test/actions/runs/20574315417/job/59087821517)
  - [성공 케이스](https://github.com/HowToBeAHappyBoy/npm-test/actions/runs/20574274165)
  - [배포된 패키지 링크](https://www.npmjs.com/package/aka-npm-test)

## 리뷰어에게

<!-- 특별히 확인해 주셨으면 하는 부분이 있나요? (예: 호버 상태, 모바일 뷰포트) -->

- 배포 전략에 맞게 잘 작성되었는지 확인 부탁드립니다

## PR 작성자 체크 리스트

- [ ] UI Review를 요청하고 검토를 받았나요?
- [ ] UI Tests를 진행했나요?

<!-- UI Review 및 UI Tests에 대한 내용은 상단 컨벤션 문서의 '7. PR리뷰 및 병합' 내용을 참고해 주세요. -->
