### PR TITLE
태그 생성 워크플로우 구현

### DIFF
--- a/.github/workflows/tagging.yml
+++ b/.github/workflows/tagging.yml
@@ -1,0 +1,44 @@
+name: Tagging 🏷️
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g., 1.2.3)"
+        required: true
+        type: string
+
+jobs:
+  create-tag:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION=$(echo "${{ github.event.pull_request.head.ref }}" | sed 's|^release/||')
+          fi
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid version format: $VERSION"
+            exit 1
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - uses: fregante/setup-git-user@v2
+
+      - name: Bump version and push tag
+        run: |
+          npm version ${{ steps.version.outputs.version }}
+          git push --follow-tags


### PR DESCRIPTION
<!-- PR에 대해 알아야 하는 내용은 위키의 컨벤션을 확인해 주세요.
위키 - https://github.com/DaleStudy/daleui/wiki/Conventions -->

## 변경 사항

`release/x.y.z` 브랜치 병합 시 자동으로 버전 태그를 생성하는 워크플로우 추가

## 목적

릴리즈 브랜치 병합 시 npm version 명령어로 package.json 버전 업데이트 및 태그 생성 자동화

## 리뷰어에게

없음

## PR 작성자 체크 리스트

이 PR은 UI 변경이 아닌 CI/CD 워크플로우 추가이므로 UI Review/Tests는 해당되지 않습니다.

- [ ] UI Review를 요청하고 검토를 받았나요?
- [ ] UI Tests를 진행했나요?

<!-- UI Review 및 UI Tests에 대한 내용은 상단 컨벤션 문서의 '7. PR리뷰 및 병합' 내용을 참고해 주세요. -->
