### PR TITLE
Dependabot의 Bun 공식 지원에 따른 설정 간소화

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,4 @@
 version: 2
-enable-beta-ecosystems: true
 updates:
   - package-ecosystem: "bun"
     pull-request-branch-name:


### PR DESCRIPTION
<!-- PR에 대해 알아야 하는 내용은 위키의 컨벤션을 확인해 주세요.
위키 - https://github.com/DaleStudy/daleui/wiki/Conventions -->

## 변경 사항

Dependabot 도입기 초안을 읽다가 궁금해서 찾아보니... Dependabot에서 Bun 지원이 이제 더 이상 베타 기능이 아니라서 `enable-beta-ecosystems` 플래그 없이도 사용 가능하더군요!

<img width="1462" height="266" alt="2025-12-29 at 16 10 06" src="https://github.com/user-attachments/assets/10e1a333-8778-4013-93cb-a7bb06d3a5ee" />

https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories#bun

<img width="880" height="230" alt="2025-12-29 at 16 10 57" src="https://github.com/user-attachments/assets/cba2c1f5-613c-4da0-9a96-4b3f991411b0" />

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#enable-beta-ecosystems-

## 목적

Dependabot 설정에서 불필요한 옵션 제거

## 리뷰어에게

@sounmind 님, 블로그 글의 점진적인 변화의 마지막 단계로 본 수정을 추가해도 좋을 것 같습니다 😁

## PR 작성자 체크 리스트

UI 변경 없음

- [ ] UI Review를 요청하고 검토를 받았나요?
- [ ] UI Tests를 진행했나요?

<!-- UI Review 및 UI Tests에 대한 내용은 상단 컨벤션 문서의 '7. PR리뷰 및 병합' 내용을 참고해 주세요. -->
