### PR TITLE
디펜더봇 쿨다운 설정 최적화

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,10 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 14
+      default-days: 14 # 일반 업데이트는 2주 대기
+      semver-major-days: 90 # Breaking Changes는 안정화를 위해 3달 대기
+      semver-minor-days: 30 # 기능 추가는 1달 대기
+      semver-patch-days: 3 # 버그/보안 수정은 가능한 빠르게
     groups:
       storybook:
         patterns:


### PR DESCRIPTION
<!-- PR에 대해 알아야 하는 내용은 위키의 컨벤션을 확인해 주세요.
위키 - https://github.com/DaleStudy/daleui/wiki/Conventions -->

## 변경 사항

최근에 발생한 React 19.0.0의 XSS 취약점에 대해서 AI와 대화를 하다가 현재 우리 프로젝트의 디펜더봇의 쿨다운 설정이 너무 길게 잡혀있다는 것을 깨닫게 되었습니다. 자세한 내용은 아래 AI의 응답을 참고 바랍니다.

```sh
Cooldown의 PR 피로도를 낮출 수 있지만 보안 측면에서는 오히려 취약해질 수 있습니다.

  | 목적                   | Cooldown이 도움? |
  |------------------------|------------------|
  | PR 피로도 감소         | ✅ 도움됨        |
  | 안정적인 기능 업데이트 | ✅ 도움됨        |
  | 보안 취약점 패치       | ❌ 해로움 |

  보안 관점에서의 문제

  Cooldown을 14일로 설정하면:
  1. 보안 취약점이 발견됨 → 패치 버전 릴리스
  2. Dependabot이 "아직 쿨다운 중이네" → PR 생성 안 함
  3. 14일 동안 취약한 버전을 계속 사용하게 됨 😱

  ★ Insight ─────────────────────────────────────
  - 최근 React 19.0.0의 XSS 취약점(2024년 12월)처럼 긴급 패치가 필요한 경우, cooldown이 길면 대응이 늦어집니다
  - Dependabot은 패치/마이너/메이저 업데이트를 구분해서 처리할 수 있습니다
  ─────────────────────────────────────────────────
```


## 목적

일반 버전 업데이트에 대해서는 충분한 쿨다운 기간을 가져가되, 보안 취약점 패치는 가급적 빨리 업데이트하기 위함.

## 리뷰어에게

<!-- 특별히 확인해 주셨으면 하는 부분이 있나요? (예: 호버 상태, 모바일 뷰포트) -->

없음

## PR 작성자 체크 리스트

UI 변경 없음

- [ ] UI Review를 요청하고 검토를 받았나요?
- [ ] UI Tests를 진행했나요?

<!-- UI Review 및 UI Tests에 대한 내용은 상단 컨벤션 문서의 '7. PR리뷰 및 병합' 내용을 참고해 주세요. -->
