### PR TITLE
릴리즈 PR 사용하지 않도록 Tagging 워크플로우 변경

### DIFF
--- a/.github/workflows/tagging.yml
+++ b/.github/workflows/tagging.yml
@@ -1,49 +1,37 @@
 name: Tagging 🏷️
 
 on:
-  pull_request:
-    types: [closed]
-    branches: [main]
   workflow_dispatch:
     inputs:
-      version:
-        description: "Version to release (e.g., 1.2.3)"
+      bump:
+        description: "Version bump type (patch/minor/major)"
         required: true
-        type: string
+        type: choice
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
 
 jobs:
   create-tag:
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v6
 
-      - name: Determine version
-        id: version
-        run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            VERSION="${{ inputs.version }}"
-          else
-            VERSION=$(echo "${{ github.event.pull_request.head.ref }}" | sed 's|^release/||')
-          fi
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Invalid version format: $VERSION"
-            exit 1
-          fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
       - uses: fregante/setup-git-user@v2
 
-      - name: Bump version and push tag
-        run: |
-          npm version ${{ steps.version.outputs.version }}
-          git push --follow-tags
+      - name: Bump version
+        run: npm version ${{ inputs.bump }}
+
+      - name: Push changes
+        run: git push --follow-tags
 
       - name: Draft release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create v${{ steps.version.outputs.version }} --draft --generate-notes
+        run: |
+          NEW_VERSION="v$(jq -r '.version' package.json)"
+          gh release create $NEW_VERSION --draft --generate-notes


### PR DESCRIPTION
<!-- PR에 대해 알아야 하는 내용은 위키의 컨벤션을 확인해 주세요.
위키 - https://github.com/DaleStudy/daleui/wiki/Conventions -->

## 변경 사항

변경된 배포 프로세스에 따라서 Tagging 워크플로우가 릴리즈 PR 없이 GitHub Actions에서 수동으로만 실행될 수 있도록 수정하였습니다.

## 목적

Tagging 워크플로우에서 버전 업이 자동으로 일어나기 때문에 릴리즈 브랜치에 개발자가 추가로 커밋해야 할 변경이 없습니다.

## 리뷰어에게

수동으로 테스트를 진행하여 변경된 워크플로우가 의도대로 작동함을 확인하였습니다.

```sh
$ gh workflow run tagging.yml --ref 710-tagging-without-release-branches -f bump=patch
```

- Workflow Run: https://github.com/DaleStudy/daleui/actions/runs/20681060344
- Tag: https://github.com/DaleStudy/daleui/releases/tag/v0.0.4
- Draft Release: https://github.com/DaleStudy/daleui/releases/tag/untagged-884619026dd9cf078d72

## PR 작성자 체크 리스트

UI 변경 없음

- [ ] UI Review를 요청하고 검토를 받았나요?
- [ ] UI Tests를 진행했나요?

<!-- UI Review 및 UI Tests에 대한 내용은 상단 컨벤션 문서의 '7. PR리뷰 및 병합' 내용을 참고해 주세요. -->
