### PR TITLE
발행 워크플로우에서 NPM 토큰을 `.npmrc` 파일 대신 환경 변수로 저장

### DIFF
--- a/.github/workflows/publication.yml
+++ b/.github/workflows/publication.yml
@@ -14,12 +14,6 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
       - name: Verify tag matches package.json
         run: |
           TAG_NAME="${{ github.event.release.tag_name }}"
@@ -34,16 +28,18 @@ jobs:
           fi
           echo "✅ 버전 일치 확인: ${TAG_VERSION}"
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
       - name: Build package
         run: |
+          bun install --frozen-lockfile
           bun run prepare
           bun run build:lib
 
       - name: Publish to npm
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
-
           bun publish
           echo "npm 배포가 완료되었습니다."


### PR DESCRIPTION
<!-- PR에 대해 알아야 하는 내용은 위키의 컨벤션을 확인해 주세요.
위키 - https://github.com/DaleStudy/daleui/wiki/Conventions -->

## 변경 사항

현재 발행 워크플로우에서 NPM 토큰을 `.npmrc` 파일에 저장하고 있습니다. 이 것은 `npm publish` 명령어를 쓸 때는 필요하지만, `bun publish` 명령어를 쓸 때는 필요가 없습니다. 왜냐면 `setup-bun` 액션이 대신 `bugfig.toml` 파일을 생성해주고 `bun publish` 명령어는 이 파일을 우선적으로 읽기 때문입니다. 따라서 우리는 [Bun 공식 문서](https://bun.sh/docs/pm/cli/publish)에 나온 것처럼 `NPM_CONFIG_TOKEN` 환경 변수에 NPM 토큰만 설정해주면 됩니다.

<img width="1366" height="200" alt="2026-01-03 at 17 17 27" src="https://github.com/user-attachments/assets/361be215-a6b8-4523-bf19-ebfe9f990ae2" />


## 목적

불필요한 `.npmrc` 파일 생성을 방지

## 리뷰어에게


## PR 작성자 체크 리스트

UI 변경 없음

- [ ] UI Review를 요청하고 검토를 받았나요?
- [ ] UI Tests를 진행했나요?

<!-- UI Review 및 UI Tests에 대한 내용은 상단 컨벤션 문서의 '7. PR리뷰 및 병합' 내용을 참고해 주세요. -->
