### PR TITLE
발행 워크플로우에서 bun publish 실행 시 scripts 무시

### DIFF
--- a/.github/workflows/publication.yml
+++ b/.github/workflows/publication.yml
@@ -40,6 +40,4 @@ jobs:
       - name: Publish to npm
         env:
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          bun publish
-          echo "npm 배포가 완료되었습니다."
+        run: bun publish --ignore-scripts # --ignore-scripts: skip prepare script (already ran in Build package step)


### PR DESCRIPTION
<!-- PR에 대해 알아야 하는 내용은 위키의 컨벤션을 확인해 주세요.
위키 - https://github.com/DaleStudy/daleui/wiki/Conventions -->

## 변경 사항

v0.0.4 패키지 발행이 실패했어요. 🥲

https://github.com/DaleStudy/daleui/blob/89a31e62c6a4f4d600a1c5ffd017f5bc1c942607/package.json#L46

<img width="2508" height="1580" alt="2026-01-07 at 19 09 11" src="https://github.com/user-attachments/assets/4445081c-c61b-4aee-8a3f-a37d72fbadd0" />

https://github.com/DaleStudy/daleui/actions/runs/20800545743

이유는 `bun publish`가 실행될 때 자동으로 `prepare` 필드에 명시되어 있는 스크립트를 실행하기 때문입니다. 그런데 `panda codegen`는 발행 워커플로우에서 이미 빌드 바로 전에 수동으로 실행됩니다. 그래서 `bun publish`가 실행될 때는 life-cycle 훅 scripts를 무시하도록 변경하였습니다.

https://github.com/DaleStudy/daleui/blob/89a31e62c6a4f4d600a1c5ffd017f5bc1c942607/.github/workflows/publication.yml#L37

## 목적

발행 워크플로우의 버그를 고치기 위함

## 리뷰어에게

N/A

## PR 작성자 체크 리스트

UI 변경 없음

- [ ] UI Review를 요청하고 검토를 받았나요?
- [ ] UI Tests를 진행했나요?

<!-- UI Review 및 UI Tests에 대한 내용은 상단 컨벤션 문서의 '7. PR리뷰 및 병합' 내용을 참고해 주세요. -->
