### PR TITLE
크로메틱 워크플로우 수동 실행

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,11 +5,11 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [labeled, synchronize]
 
 jobs:
   pre-chromatic:
-    if: (github.event_name == 'push' || github.event.pull_request.draft == false) && github.actor != 'dependabot[bot]'
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ui')
     runs-on: ubuntu-latest
     steps:
       - id: gen_url
@@ -21,7 +21,7 @@ jobs:
       url: ${{ steps.gen_url.outputs.url }}
 
   chromatic:
-    if: (github.event_name == 'push' || github.event.pull_request.draft == false) && github.actor != 'dependabot[bot]'
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ui')
     environment:
       name: chromatic
       url: ${{ needs.pre-chromatic.outputs.url }}


### PR DESCRIPTION
<!-- PR에 대해 알아야 하는 내용은 위키의 컨벤션을 확인해 주세요.
위키 - https://github.com/DaleStudy/daleui/wiki/Conventions -->

## 변경 사항

<!-- 무엇을 변경했나요? (예: 새 컴포넌트 추가, 디자인 수정, 문서 업데이트) -->

`ui` 레이블을 통해서 크로메틱 활성화 여부를 통제할 수 있도록 워크플로우를 변경합니다. PR에 `ui` 레이블이 추가되었을 때, 그리고 `ui` 레이블이 달린 체로 PR에 커밋이 추가될 때마다 크로메틱이 돌아갑니다. `ui` 레이블을 제거하면 다시 크로메틱이 비활성화됩니다. 이를 통해, 개발자 경험에 대한 영향을 최소화 하면서 불필요한 크로메틱 실행을 최소화하려고 합니다.

## 목적

<!-- 왜 이 변경이 필요한가요? (예: 접근성 개선, 사용자 경험 향상) -->

PR이 Draft 상태일 때는 크로메틱 실행을 막았음에도 불구하고, 무료 사용량을 아슬아슬 버티다가 1월달에 결국 다시 초과하였습니다.

<img width="1504" height="1272" alt="image" src="https://github.com/user-attachments/assets/ed517883-8957-4bcd-a76b-1cfcf672ddda" />



## 리뷰어에게

<!-- 특별히 확인해 주셨으면 하는 부분이 있나요? (예: 호버 상태, 모바일 뷰포트) -->

-

## PR 작성자 체크 리스트

- [ ] UI Review를 요청하고 검토를 받았나요?
- [ ] UI Tests를 진행했나요?

<!-- UI Review 및 UI Tests에 대한 내용은 상단 컨벤션 문서의 '7. PR리뷰 및 병합' 내용을 참고해 주세요. -->
