### PR TITLE
RadioGroup invalid/required 상태 및 스타일 추가

### DIFF
--- a/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
 import { css } from "../../../styled-system/css";
 import { Radio, RadioGroup } from "./RadioGroup";
+import { VStack } from "../VStack/VStack";
 
 export default {
   component: RadioGroup,
@@ -209,4 +210,85 @@ export const Controlled = () => {
       </div>
     </div>
   );
+};
+
+export const Invalid: Story = {
+  render: (args) => {
+    return (
+      <VStack gap="32">
+        <RadioGroup
+          {...args}
+          name="invalid-unselected"
+          label="에러 상태 (선택 없음)"
+          invalid
+        />
+
+        <RadioGroup
+          {...args}
+          name="invalid-selected"
+          label="에러 상태 (선택됨)"
+          invalid
+          defaultValue="banana"
+        />
+
+        <RadioGroup
+          {...args}
+          name="normal"
+          label="정상 상태 (비교용)"
+          defaultValue="apple"
+        />
+      </VStack>
+    );
+  },
+  argTypes: {
+    name: {
+      control: false,
+    },
+    label: {
+      control: false,
+    },
+    invalid: {
+      control: false,
+    },
+    defaultValue: {
+      control: false,
+    },
+  },
+};
+
+export const Required: Story = {
+  render: (args) => {
+    return (
+      <VStack gap="32">
+        <RadioGroup
+          {...args}
+          name="required-normal"
+          label="필수 입력"
+          required
+        />
+
+        <RadioGroup
+          {...args}
+          name="required-disabled"
+          label="필수 입력 (비활성화)"
+          required
+          disabled
+        />
+      </VStack>
+    );
+  },
+  argTypes: {
+    name: {
+      control: false,
+    },
+    label: {
+      control: false,
+    },
+    required: {
+      control: false,
+    },
+    disabled: {
+      control: false,
+    },
+  },
 };

--- a/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/src/components/RadioGroup/RadioGroup.test.tsx
@@ -234,7 +234,7 @@ describe("Radio", () => {
   test.each([
     ["neutral", "bd-c_slate.9"],
     ["brand", "bd-c_slate.9"],
-    ["danger", "bd-c_slate.9"],
+    ["danger", "bd-c_fg.danger"],
     ["warning", "bd-c_slate.9"],
     ["success", "bd-c_slate.9"],
     ["info", "bd-c_slate.9"],
@@ -250,5 +250,179 @@ describe("Radio", () => {
 
     // 모든 tone에서 일반 상태에는 slate.9 사용
     expect(indicator).toHaveClass(className);
+  });
+});
+
+describe("RadioGroup invalid", () => {
+  test("invalid prop이 없을 때 aria-invalid='false'", () => {
+    render(
+      <RadioGroup name="test" label="Test Radio Group">
+        <Radio value="option1">Option 1</Radio>
+      </RadioGroup>,
+    );
+
+    const radio = screen.getByLabelText("Option 1");
+    expect(radio).toHaveAttribute("aria-invalid", "false");
+  });
+
+  test("invalid={true}일 때 aria-invalid='true'", () => {
+    render(
+      <RadioGroup name="test" label="Test Radio Group" invalid>
+        <Radio value="option1">Option 1</Radio>
+      </RadioGroup>,
+    );
+
+    const radio = screen.getByLabelText("Option 1");
+    expect(radio).toHaveAttribute("aria-invalid", "true");
+  });
+
+  test("invalid={false}일 때 aria-invalid='false'", () => {
+    render(
+      <RadioGroup name="test" label="Test Radio Group" invalid={false}>
+        <Radio value="option1">Option 1</Radio>
+      </RadioGroup>,
+    );
+
+    const radio = screen.getByLabelText("Option 1");
+    expect(radio).toHaveAttribute("aria-invalid", "false");
+  });
+
+  test("invalid와 disabled를 함께 사용할 수 있다", () => {
+    render(
+      <RadioGroup name="test" label="Test Radio Group" invalid disabled>
+        <Radio value="option1">Option 1</Radio>
+      </RadioGroup>,
+    );
+
+    const radio = screen.getByLabelText("Option 1");
+    expect(radio).toHaveAttribute("aria-invalid", "true");
+    expect(radio).toBeDisabled();
+  });
+
+  test("invalid 상태에서도 선택 기능이 정상 동작한다", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <RadioGroup
+        name="test"
+        label="Test Radio Group"
+        invalid
+        onChange={onChange}
+      >
+        <Radio value="option1">Option 1</Radio>
+        <Radio value="option2">Option 2</Radio>
+      </RadioGroup>,
+    );
+
+    const option1 = screen.getByLabelText("Option 1");
+    await user.click(option1);
+
+    expect(onChange).toHaveBeenCalledWith("option1");
+    expect(option1).toBeChecked();
+  });
+
+  test("invalid 상태일 때 danger 색상 스타일이 적용된다", () => {
+    render(
+      <RadioGroup name="test" label="Test Radio Group" invalid>
+        <Radio value="option1">Option 1</Radio>
+      </RadioGroup>,
+    );
+
+    const circle = screen.getByRole("presentation", { hidden: true });
+    expect(circle).toHaveClass("bd-c_fg.danger");
+  });
+});
+
+describe("RadioGroup required", () => {
+  test("required={true}이면 필수 표시(*)가 렌더링된다", () => {
+    render(
+      <RadioGroup name="test" label="Test Radio Group" required>
+        <Radio value="option1">Option 1</Radio>
+      </RadioGroup>,
+    );
+
+    const indicator = screen.getByTestId("radiogroup-required-indicator");
+    expect(indicator).toBeInTheDocument();
+    expect(indicator).toHaveTextContent("*");
+  });
+
+  test("required={false}이면 필수 표시가 없다", () => {
+    render(
+      <RadioGroup name="test" label="Test Radio Group" required={false}>
+        <Radio value="option1">Option 1</Radio>
+      </RadioGroup>,
+    );
+
+    expect(
+      screen.queryByTestId("radiogroup-required-indicator"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("required prop이 없으면 필수 표시가 없다", () => {
+    render(
+      <RadioGroup name="test" label="Test Radio Group">
+        <Radio value="option1">Option 1</Radio>
+      </RadioGroup>,
+    );
+
+    expect(
+      screen.queryByTestId("radiogroup-required-indicator"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("required와 disabled가 함께 있으면 비활성화 색상이 적용된다", () => {
+    render(
+      <RadioGroup name="test" label="Test Radio Group" required disabled>
+        <Radio value="option1">Option 1</Radio>
+      </RadioGroup>,
+    );
+
+    const indicator = screen.getByTestId("radiogroup-required-indicator");
+    expect(indicator).toHaveClass("c_fg.neutral.disabled");
+  });
+
+  test("required만 있으면 danger 색상이 적용된다", () => {
+    render(
+      <RadioGroup name="test" label="Test Radio Group" required>
+        <Radio value="option1">Option 1</Radio>
+      </RadioGroup>,
+    );
+
+    const indicator = screen.getByTestId("radiogroup-required-indicator");
+    expect(indicator).toHaveClass("c_fg.danger");
+  });
+
+  test("required prop이 없을 때 aria-required='false'", () => {
+    render(
+      <RadioGroup name="test" label="Test Radio Group">
+        <Radio value="option1">Option 1</Radio>
+      </RadioGroup>,
+    );
+
+    const radio = screen.getByLabelText("Option 1");
+    expect(radio).toHaveAttribute("aria-required", "false");
+  });
+
+  test("required={true}일 때 aria-required='true'", () => {
+    render(
+      <RadioGroup name="test" label="Test Radio Group" required>
+        <Radio value="option1">Option 1</Radio>
+      </RadioGroup>,
+    );
+
+    const radio = screen.getByLabelText("Option 1");
+    expect(radio).toHaveAttribute("aria-required", "true");
+  });
+
+  test("required={false}일 때 aria-required='false'", () => {
+    render(
+      <RadioGroup name="test" label="Test Radio Group" required={false}>
+        <Radio value="option1">Option 1</Radio>
+      </RadioGroup>,
+    );
+
+    const radio = screen.getByLabelText("Option 1");
+    expect(radio).toHaveAttribute("aria-required", "false");
   });
 });


### PR DESCRIPTION
## 변경 사항

- `RadioGroup`에 `invalid`, `required` props를 추가했습니다.
  - `invalid`일 때 라디오 서클/도트/hover 영역, 라벨 텍스트에 danger 톤이 적용되도록 했습니다.
  - `required`일 때 라벨 옆에 `*` 표시를 렌더링하고, disabled 여부에 따라 색상이 달라지도록 했습니다.
- `Radio` 컴포넌트에서 `RadioGroupContext`의 `invalid`, `required` 값을 사용해
  - `aria-invalid`, `aria-required` 속성을 설정하고
  - 스타일 variant(`invalid`)가 적용되도록 수정했습니다.
- Storybook에 다음 상태를 확인할 수 있는 스토리를 추가했습니다.
  - Invalid
  - Required
  - InvalidAndRequired
- `RadioGroup` invalid / required 동작과 관련된 유닛 테스트를 추가했습니다.
  - `aria-invalid`, `aria-required` 값 검증
  - required indicator 렌더링 여부 및 색상 검증
  - invalid 상태에서도 선택/변경 이벤트가 정상 동작하는지 검증

## 목적

- 폼 유효성 검증 시 라디오 그룹의 에러 상태를 시각적으로 명확하게 보여주기 위함입니다.
- 필수 입력 라디오 `그룹에` 대해 시각적인 표시와 ARIA 속성을 제공해 접근성을 개선하기 위함입니다.
- 향후 CheckboxGroup 등 다른 Form 컴포넌트와 invalid / required 패턴을 일관되게 가져가기 위한 기반 작업입니다.

## 리뷰어에게

- `RadioGroupContext`에 `invalid`, `required`를 추가하고 `Radio`에서 이를 꺼내 쓰는 구조가 괜찮은지 봐주시면 좋겠습니다.
- Invalid / Required 스토리 구성이 실제 사용 케이스를 이해하는 데 충분한지도 봐주시면 좋겠습니다.

## PR 작성자 체크 리스트

- [ ] UI Review를 요청하고 검토를 받았나요?
- [ ] UI Tests를 진행했나요?