### PR TITLE
PasswordInput Safari UI 깨짐 이슈

### DIFF
--- a/src/components/PasswordInput/PasswordInput.tsx
+++ b/src/components/PasswordInput/PasswordInput.tsx
@@ -140,6 +140,7 @@ const containerStyles = cva({
 const inputStyles = cva({
   base: {
     flex: "1",
+    minWidth: 0,
     border: "none",
     outline: "none",
     color: "fg.neutral.default",


### PR DESCRIPTION
<!-- PR에 대해 알아야 하는 내용은 위키의 컨벤션을 확인해 주세요.
위키 - https://github.com/DaleStudy/daleui/wiki/Conventions -->

<!-- 무엇을 왜 변경했나요? (예: 접근성 개선을 위해 Button 컴포넌트에 disabled prop 추가) -->

flex 컨테이너에서 input이 기본 min-width: auto 때문에 줄어들지 않아 Safari에서 버튼이 밀리는 문제가 발생하였고, 
`min-width: 0`을 추가해 해결하였습니다.

## 테스팅

<!-- 변경 사항이 의도대로 동작하는지 어떻게 확인했나요? (예: 스크린샷 또는 비디오 첨부, 테스트 단계 설명) -->
<img width="1912" height="748" alt="스크린샷 2026-03-20 오전 11 40 56" src="https://github.com/user-attachments/assets/f04d2115-18bf-4029-b023-40d25488adc4" />

로컬에서 확인하였습니다. 

## 체크 리스트

- [x] 코드 리뷰를 요청하기 전에 반드시 CI가 통과하는지 확인해주세요.
- [x] 컴포넌트나 스토리 변경이 있는 경우 PR에 ui 태그를 달아주세요.
  - [x] UI Tests를 통해 스냅샷 차이가 의도된 것인지 확인해주세요.
  - [ ] UI Review를 통해 디자이너에게 리뷰를 요청하고 승인을 받으세요.

<!-- UI Review 및 UI Tests에 대한 내용은 상단 컨벤션 문서의 '7. PR리뷰 및 병합' 내용을 참고해 주세요. -->
