### PR TITLE
chore: add source map files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ storybook-static
 ## Coverage
 coverage
 
+# Source maps
+*.map
+


### PR DESCRIPTION
<!-- PR에 대해 알아야 하는 내용은 위키의 컨벤션을 확인해 주세요.
위키 - https://github.com/DaleStudy/daleui/wiki/Conventions -->

<!-- 무엇을 왜 변경했나요? (예: 접근성 개선을 위해 Button 컴포넌트에 disabled prop 추가) -->

현재 Vite 프로덕션 빌드에서 소스 맵을 생성하지 않지만, 향후 누군가 빌드 설정에서 `sourcemap: true`를 켤 경우 `.map` 파일이 저장소에 커밋되는 것을 방지하기 위해 `.gitignore`에 `*.map` 패턴을 추가합니다. 최근 Claude Code 코드 유출 사고처럼 소스맵에는 원본 소스 코드를 복원할 수 있는 매핑 정보가 담겨 있어, 공개 저장소에 포함되면 보안상 민감할 수 있습니다. 우리는 어차피 오픈 소스라서 큰 위험은 아니지만, 그래도 일반적인 보안 모범 관행은 따르고자 합니다.

# Testing

## 테스팅

<!-- 변경 사항이 의도대로 동작하는지 어떻게 확인했나요? (예: 스크린샷 또는 비디오 첨부, 테스트 단계 설명) -->

## 체크 리스트

- [ ] 코드 리뷰를 요청하기 전에 반드시 CI가 통과하는지 확인해주세요.
- [ ] 컴포넌트나 스토리 변경이 있는 경우 PR에 ui 태그를 달아주세요.
  - [ ] UI Tests를 통해 스냅샷 차이가 의도된 것인지 확인해주세요.
  - [ ] UI Review를 통해 디자이너에게 리뷰를 요청하고 승인을 받으세요.

<!-- UI Review 및 UI Tests에 대한 내용은 상단 컨벤션 문서의 '7. PR리뷰 및 병합' 내용을 참고해 주세요. -->
