### PR TITLE
모든 컴포넌트 ref 전달 지원

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,12 +38,15 @@ jobs:
           bun install
           bun run build:lib
 
+      - name: Pack library
+        run: npm pack
+
       - name: Create test project & install daleui
         run: |
           mkdir /tmp/test-project && cd /tmp/test-project
-          bun create vite@5 . --template react-ts
+          bun create vite@latest . --template react-ts
           bun install
-          bun add "$GITHUB_WORKSPACE"
+          bun add "$GITHUB_WORKSPACE"/daleui-*.tgz
 
       - name: Add daleui smoke test
         run: |

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "prepare": "panda codegen"
   },
   "peerDependencies": {
-    "react": "^18.0.0 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "dependencies": {
     "@ark-ui/react": "^5.34.1",

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -28,6 +28,8 @@ export interface BoxProps extends React.HTMLAttributes<HTMLElement> {
   width?: CSSLength;
   /** 높이 (예: "100px", "2rem", "2em", "50%") */
   height?: CSSLength;
+  /** 요소 참조 */
+  ref?: React.Ref<HTMLElement>;
 }
 
 /**
@@ -41,6 +43,7 @@ export interface BoxProps extends React.HTMLAttributes<HTMLElement> {
  */
 
 export const Box = ({
+  ref,
   children,
   as = "div",
   padding,
@@ -50,8 +53,6 @@ export const Box = ({
   className,
   ...rest
 }: BoxProps) => {
-  const Component = as;
-
   const baseStyle = css({
     padding,
     margin,
@@ -62,13 +63,14 @@ export const Box = ({
     ...(height !== undefined && { height }),
   };
 
-  return (
-    <Component
-      className={cx(baseStyle, className)}
-      style={inlineStyle}
-      {...rest}
-    >
-      {children}
-    </Component>
+  return React.createElement(
+    as,
+    {
+      ref,
+      className: cx(baseStyle, className),
+      style: inlineStyle,
+      ...rest,
+    },
+    children,
   );
 };

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { type HTMLAttributes } from "react";
+import { type HTMLAttributes, type Ref } from "react";
 import { css, cva, cx } from "../../../styled-system/css";
 import { Icon } from "../Icon/Icon";
 import { hstack } from "../../../styled-system/patterns";
@@ -26,12 +26,15 @@ export interface ButtonProps extends Omit<
   type?: "button" | "submit" | "reset";
   /** 스타일 변형 */
   variant?: "solid" | "outline" | "ghost";
+  /** 요소 참조 */
+  ref?: Ref<HTMLButtonElement>;
 }
 
 /**
  * 버튼은 사용자의 명확한 작업 실행을 위해 사용되는 컴포넌트로, 완료, 저장, 제출과 같은 액션에 사용합니다.
  */
 export const Button = ({
+  ref,
   className,
   children,
   variant = "solid",
@@ -46,6 +49,7 @@ export const Button = ({
 
   return (
     <button
+      ref={ref}
       type={type}
       {...rest}
       className={cx(

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -2,6 +2,7 @@ import type {
   AnchorHTMLAttributes,
   HTMLAttributes,
   ReactNode,
+  Ref,
   SVGProps,
 } from "react";
 import { createContext, useContext } from "react";
@@ -32,9 +33,12 @@ export interface CardProps extends Omit<HTMLAttributes<HTMLElement>, "style"> {
   outline?: boolean;
   /** 자식 요소 */
   children: ReactNode;
+  /** 요소 참조 */
+  ref?: Ref<HTMLElement>;
 }
 
 function CardRoot({
+  ref,
   tone = "neutral",
   outline = false,
   className,
@@ -44,6 +48,7 @@ function CardRoot({
   return (
     <CardContext.Provider value={{ tone }}>
       <article
+        ref={ref}
         className={cx(rootStyles({ tone, outline }), className)}
         {...rest}
       >
@@ -57,11 +62,13 @@ export interface CardBodyProps extends Omit<
   "style"
 > {
   children: ReactNode;
+  /** 요소 참조 */
+  ref?: Ref<HTMLDivElement>;
 }
 
-export function CardBody({ className, children, ...rest }: CardBodyProps) {
+export function CardBody({ ref, className, children, ...rest }: CardBodyProps) {
   return (
-    <div className={cx(bodyStyles(), className)} {...rest}>
+    <div ref={ref} className={cx(bodyStyles(), className)} {...rest}>
       {children}
     </div>
   );

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -21,6 +21,8 @@ export interface CheckboxProps extends FieldProps {
   tone?: Tone;
   /** 체크 변경 핸들러 */
   onChange?: (checked: boolean) => void;
+  /** 입력 요소 참조 */
+  ref?: React.Ref<HTMLInputElement>;
 }
 
 /**
@@ -28,6 +30,7 @@ export interface CheckboxProps extends FieldProps {
  * 개별 항목의 상태를 '선택(Checked)' 또는 '해제(Unchecked)'로 변경하는 기능을 수행합니다.
  */
 export const Checkbox = ({
+  ref,
   label,
   name,
   checked,
@@ -82,7 +85,11 @@ export const Checkbox = ({
           )}
         </ArkCheckbox.Label>
       )}
-      <ArkCheckbox.HiddenInput data-test-tone={tone} aria-required={required} />
+      <ArkCheckbox.HiddenInput
+        ref={ref}
+        data-test-tone={tone}
+        aria-required={required}
+      />
     </ArkCheckbox.Root>
   );
 };

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -1,4 +1,10 @@
-import { type ReactNode, createContext, useContext, useState } from "react";
+import {
+  type ReactNode,
+  type Ref,
+  createContext,
+  useContext,
+  useState,
+} from "react";
 import { css, cva } from "../../../styled-system/css";
 import type { Tone } from "../../tokens/colors";
 import type { FieldProps } from "../shared/types";
@@ -38,6 +44,9 @@ export interface CheckboxGroupProps extends FieldProps {
 
   /** 색조 */
   tone?: Tone;
+
+  /** 요소 참조 */
+  ref?: Ref<HTMLDivElement>;
 }
 
 /**
@@ -54,6 +63,7 @@ export interface CheckboxGroupProps extends FieldProps {
  * </CheckboxGroup>
  */
 export function CheckboxGroup({
+  ref,
   children,
   name,
   label,
@@ -96,7 +106,7 @@ export function CheckboxGroup({
         onValueChange: handleValueChange,
       }}
     >
-      <div className={checkboxGroupRootStyles}>
+      <div ref={ref} className={checkboxGroupRootStyles}>
         <label
           className={css({
             textStyle: "label.md.strong",

--- a/src/components/Flex/Flex.tsx
+++ b/src/components/Flex/Flex.tsx
@@ -25,6 +25,8 @@ export interface FlexProps
   gap?: Spacing;
   /** ARIA 역할 */
   role?: AriaRole;
+  /** 요소 참조 */
+  ref?: React.Ref<HTMLElement>;
 }
 
 /**
@@ -48,6 +50,7 @@ export interface FlexProps
  * - **Flex** — `direction` 전환이 필요하거나, 교차축 정렬이 가운데가 아닐 때(`stretch`·`start`·`end` 등) 사용합니다.
  */
 export const Flex = ({
+  ref,
   children,
   as = "div",
   direction = "row",
@@ -57,11 +60,10 @@ export const Flex = ({
   className,
   ...rest
 }: FlexProps) => {
-  const Component = as;
-
   return React.createElement(
-    Component,
+    as,
     {
+      ref,
       className: cx(
         flexVariants({
           direction,

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -57,6 +57,8 @@ export interface GridProps
   justifyContent?: RecipeVariant<typeof gridVariants>["justifyContent"];
   /** 컨테이너 교차축 정렬 (align-content) */
   alignContent?: RecipeVariant<typeof gridVariants>["alignContent"];
+  /** 요소 참조 */
+  ref?: React.Ref<HTMLElement>;
 }
 
 /**
@@ -68,6 +70,7 @@ export interface GridProps
  * - 접근성을 위해 기본적으로 적절한 HTML 시맨틱 요소를 사용하고 필요시 ARIA 속성을 활용하여 접근성을 향상시킵니다.
  */
 export const Grid = ({
+  ref,
   children,
   as = "div",
   gridTemplateColumns,
@@ -82,11 +85,10 @@ export const Grid = ({
   className,
   ...props
 }: GridProps) => {
-  const Component = as;
-
   return React.createElement(
-    Component,
+    as,
     {
+      ref,
       className: cx(
         gridVariants({
           autoFlow,
@@ -180,6 +182,8 @@ export interface GridItemProps extends React.HTMLAttributes<HTMLElement> {
   gridRowEnd?: string;
   /** 영역 이름 (grid-area) */
   gridArea?: string;
+  /** 요소 참조 */
+  ref?: React.Ref<HTMLElement>;
 }
 
 /**
@@ -190,6 +194,7 @@ export interface GridItemProps extends React.HTMLAttributes<HTMLElement> {
  * - 접근성을 위해 기본적으로 적절한 HTML 시맨틱 요소를 사용하고 필요시 ARIA 속성을 활용하여 접근성을 향상시킵니다.
  */
 export const GridItem = ({
+  ref,
   children,
   as = "div",
   gridColumn,
@@ -202,8 +207,6 @@ export const GridItem = ({
   className,
   ...props
 }: GridItemProps) => {
-  const Component = as;
-
   // 유효하지 않은 css 변수가 주어질 때 auto로 처리하지 않도록 null 체크
   const placementStyle = {
     ...(gridColumn != null && { "--grid-column": gridColumn }),
@@ -228,8 +231,9 @@ export const GridItem = ({
   };
 
   return React.createElement(
-    Component,
+    as,
     {
+      ref,
       className: cx(css(placementCss), className),
       style: placementStyle,
       ...props,

--- a/src/components/HStack/HStack.tsx
+++ b/src/components/HStack/HStack.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Flex } from "../Flex/Flex";
 import type { FlexProps } from "../Flex/Flex";
 
@@ -27,6 +28,8 @@ export interface HStackProps extends Omit<
   justify?: Justify;
   /** 세로 정렬 */
   align?: Align;
+  /** 요소 참조 */
+  ref?: React.Ref<HTMLElement>;
 }
 
 /**
@@ -45,6 +48,7 @@ export const HStack = ({
   reversed = false,
   gap,
   className,
+  ref,
   ...rest
 }: HStackProps) => {
   const direction = reversed ? "rowReverse" : "row";
@@ -52,6 +56,7 @@ export const HStack = ({
   const alignContent = alignVariants[align];
   return (
     <Flex
+      ref={ref}
       as={as}
       direction={direction}
       justify={justifyContent}

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes, ReactNode } from "react";
+import React, { type HTMLAttributes, type ReactNode } from "react";
 import { css, cva } from "../../../styled-system/css";
 
 type Level = 1 | 2 | 3 | 4 | 5;
@@ -20,6 +20,8 @@ export interface HeadingProps extends HTMLAttributes<HTMLHeadingElement> {
   align?: Align;
   /** 줄바꿈 규칙 */
   wordBreak?: WordBreak;
+  /** 요소 참조 */
+  ref?: React.Ref<HTMLHeadingElement>;
 }
 
 /**
@@ -31,6 +33,7 @@ export interface HeadingProps extends HTMLAttributes<HTMLHeadingElement> {
  * - 반응형 폰트를 지원하여 뷰포트에 따라 글꼴 크기가 자동으로 전환됩니다.
  */
 export const Heading = ({
+  ref,
   children,
   level,
   size,
@@ -47,9 +50,11 @@ export const Heading = ({
 
   const Tag = `h${level}` as const;
 
-  return (
-    <Tag
-      className={css(
+  return React.createElement(
+    Tag,
+    {
+      ref,
+      className: css(
         styles.raw({
           level: size ? undefined : level,
           tone,
@@ -60,11 +65,10 @@ export const Heading = ({
           css.raw({
             textStyle: `heading.${size}`,
           }),
-      )}
-      {...rest}
-    >
-      {children}
-    </Tag>
+      ),
+      ...rest,
+    },
+    children,
   );
 };
 

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes, ReactElement } from "react";
+import type { HTMLAttributes, ReactElement, Ref } from "react";
 import { css, cva } from "../../../styled-system/css";
 import type { ButtonProps } from "../Button/Button";
 import type { TextInputProps } from "../TextInput/TextInput";
@@ -27,6 +27,8 @@ export interface LabelProps extends HTMLAttributes<HTMLLabelElement> {
   required?: boolean;
   /** 연결 대상 요소 id */
   htmlFor?: string;
+  /** 요소 참조 */
+  ref?: Ref<HTMLLabelElement>;
 }
 
 /**
@@ -43,6 +45,7 @@ export interface LabelProps extends HTMLAttributes<HTMLLabelElement> {
  * - `htmlFor` 또는 `children`으로 입력 요소를 연결하면, 라벨 클릭 시 해당 입력 요소로 포커스가 이동합니다.
  */
 export function Label({
+  ref,
   children,
   labelText,
   tone = "neutral",
@@ -52,6 +55,7 @@ export function Label({
 }: LabelProps) {
   return (
     <label
+      ref={ref}
       className={styles({
         tone: disabled ? undefined : tone,
         disabled,

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,4 +1,4 @@
-import { type AnchorHTMLAttributes } from "react";
+import { type AnchorHTMLAttributes, type Ref } from "react";
 import { css, cva } from "../../../styled-system/css";
 import { textStyles } from "../../tokens/typography";
 
@@ -18,6 +18,8 @@ export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   underline?: boolean;
   /** 외부 링크·새 탭 열기 여부 */
   external?: boolean;
+  /** 요소 참조 */
+  ref?: Ref<HTMLAnchorElement>;
 }
 
 /**
@@ -34,6 +36,7 @@ export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
  * - `external`이 true일 때, 외부 링크 아이콘(`externalLink`)을 함께 제공하지 않으면 시각적 안내 부족으로 접근성 문제가 발생할 수 있습니다.
  */
 export function Link({
+  ref,
   href,
   children,
   tone = "brand",
@@ -47,6 +50,7 @@ export function Link({
 
   return (
     <a
+      ref={ref}
       className={css(
         styles.raw({ tone, underline, size }),
         textStyles.label[size].DEFAULT.value,

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -24,10 +24,10 @@ export interface SelectProps
   onChange?: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   /** 접근성 레이블 (aria-label) */
   "aria-label"?: string;
-  /** select 요소 참조 */
-  ref?: Ref<HTMLSelectElement>;
   /** 폼 name */
   name?: string;
+  /** select 요소 참조 */
+  ref?: Ref<HTMLSelectElement>;
 }
 
 /**

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,5 +1,10 @@
 import type React from "react";
-import type { AnchorHTMLAttributes, HTMLAttributes, ReactNode } from "react";
+import type {
+  AnchorHTMLAttributes,
+  HTMLAttributes,
+  ReactNode,
+  Ref,
+} from "react";
 import { css, cva } from "../../../styled-system/css";
 import type { Tone } from "../../tokens/colors";
 import { Icon } from "../Icon/Icon";
@@ -11,6 +16,8 @@ type BaseTagProps = {
   tone?: Tone;
   /** 제거 핸들러 (설정 시 제거 버튼 표시) */
   onRemove?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  /** 요소 참조 */
+  ref?: Ref<HTMLSpanElement>;
 };
 
 /** href가 있으면 자동으로 <a> 로 렌더링 */
@@ -34,6 +41,7 @@ export type TagProps = TagAsLink | TagAsSpan;
  * - `href`를 전달하면 자동으로 `<a>` 태그로 렌더링됩니다.
  */
 export function Tag({
+  ref,
   children,
   tone = "neutral",
   href,
@@ -56,7 +64,7 @@ export function Tag({
       target === "_blank" ? (propRel ?? "noopener noreferrer") : propRel;
 
     return (
-      <span className={styles({ tone, link: true })}>
+      <span ref={ref} className={styles({ tone, link: true })}>
         <a
           href={href}
           target={target}
@@ -83,7 +91,7 @@ export function Tag({
   const spanRest = rest as HTMLAttributes<HTMLSpanElement>;
 
   return (
-    <span className={styles({ tone, link: false })} {...spanRest}>
+    <span ref={ref} className={styles({ tone, link: false })} {...spanRest}>
       {children}
       {onRemove && (
         <button

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes, ReactNode } from "react";
+import React, { type HTMLAttributes, type ReactNode } from "react";
 import { css, cva } from "../../../styled-system/css";
 import type { Tone } from "../../tokens/colors";
 import type { FontSize, FontWeight } from "../../tokens/typography";
@@ -16,6 +16,8 @@ export interface TextProps extends HTMLAttributes<HTMLElement> {
   weight?: FontWeight;
   /** 흐린 톤(muted) 적용 여부 */
   muted?: boolean;
+  /** 요소 참조 */
+  ref?: React.Ref<HTMLElement>;
 }
 
 /**
@@ -24,6 +26,7 @@ export interface TextProps extends HTMLAttributes<HTMLElement> {
  * - `muted` 속성을 주시면 글자색이 옅어집니다. 명암비가 낮아지므로 접근성 측면에서 주의해서 사용하세요.
  */
 export const Text = ({
+  ref,
   children,
   as: Tag = "span",
   tone = "neutral",
@@ -32,19 +35,20 @@ export const Text = ({
   muted = false,
   ...rest
 }: TextProps) => {
-  return (
-    <Tag
-      className={css(
+  return React.createElement(
+    Tag,
+    {
+      ref,
+      className: css(
         styles.raw({ tone, muted }),
         css.raw({
           fontSize: size,
           fontWeight: weight,
         }),
-      )}
-      {...rest}
-    >
-      {children}
-    </Tag>
+      ),
+      ...rest,
+    },
+    children,
   );
 };
 

--- a/src/components/VStack/VStack.tsx
+++ b/src/components/VStack/VStack.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Flex } from "../Flex/Flex";
 import type { FlexProps } from "../Flex/Flex";
 
@@ -29,6 +30,8 @@ export interface VStackProps extends Omit<
   justify?: Justify;
   /** 가로 정렬 */
   align?: Align;
+  /** 요소 참조 */
+  ref?: React.Ref<HTMLElement>;
 }
 
 /**
@@ -48,6 +51,7 @@ export const VStack = ({
   reversed = false,
   gap,
   className,
+  ref,
   ...rest
 }: VStackProps) => {
   const direction = reversed ? "columnReverse" : "column";
@@ -56,6 +60,7 @@ export const VStack = ({
 
   return (
     <Flex
+      ref={ref}
       as={as}
       direction={direction}
       justify={justifyContent}


### PR DESCRIPTION
Closes #842

모든 컴포넌트가 ref props 형식을 사용하여 ref를 전달하도록 변경했습니다(React 19+ 호환 지원).

CI install-test에서 symlink 대신 `bun pack` tarball 설치 방식으로 변경하여 `@types/react` 버전 충돌(18 vs 19)을 해결했습니다.

## 체크 리스트

- [X] 코드 리뷰를 요청하기 전에 반드시 CI가 통과하는지 확인해주세요.
- [ ] 컴포넌트나 스토리 변경이 있는 경우 PR에 ui 태그를 달아주세요.
  - [ ] UI Tests를 통해 스냅샷 차이가 의도된 것인지 확인해주세요.
  - [ ] UI Review를 통해 디자이너에게 리뷰를 요청하고 승인을 받으세요.

<!-- UI Review 및 UI Tests에 대한 내용은 상단 컨벤션 문서의 '7. PR리뷰 및 병합' 내용을 참고해 주세요. -->