### PR TITLE
Layout padding prop 지원

### DIFF
--- a/src/components/Flex/Flex.stories.tsx
+++ b/src/components/Flex/Flex.stories.tsx
@@ -37,6 +37,7 @@ export default {
       description: "교차축 정렬 방식",
     },
     gap: { control: "select", options: Object.keys(spacing || {}) },
+    padding: { control: "select", options: Object.keys(spacing || {}) },
     className: { control: false },
   },
   args: {
@@ -102,6 +103,26 @@ export const Gaps: Story = {
   argTypes: {
     children: { control: false },
     gap: { control: false },
+  },
+  args: {},
+};
+
+export const Padding: Story = {
+  render: (args) => (
+    <div>
+      <div>
+        <h4>padding: 16</h4>
+        <Flex {...args} padding="16" />
+      </div>
+      <div>
+        <h4>padding: 32</h4>
+        <Flex {...args} padding="32" />
+      </div>
+    </div>
+  ),
+  argTypes: {
+    children: { control: false },
+    padding: { control: false },
   },
   args: {},
 };

--- a/src/components/Flex/Flex.stories.tsx
+++ b/src/components/Flex/Flex.stories.tsx
@@ -124,7 +124,6 @@ export const Padding: Story = {
     children: { control: false },
     padding: { control: false },
   },
-  args: {},
 };
 
 export const Justify: Story = {

--- a/src/components/Flex/Flex.test.tsx
+++ b/src/components/Flex/Flex.test.tsx
@@ -109,6 +109,20 @@ describe("클래스 토큰 및 스타일", () => {
       screen.getByRole("navigation", { name: `flex-gap-${gap}` }).className,
     ).toMatch(`gap_${gap}`);
   });
+
+  const paddings = Object.keys(spacing || {}) as Spacing[];
+  test.each(paddings)("padding=%s이면 p_%s 클래스가 적용된다", (padding) => {
+    render(
+      <Flex as="nav" aria-label={`flex-padding-${padding}`} padding={padding}>
+        <span>child</span>
+      </Flex>,
+    );
+
+    expect(
+      screen.getByRole("navigation", { name: `flex-padding-${padding}` })
+        .className,
+    ).toMatch(`p_${padding}`);
+  });
 });
 
 describe("Flex 접근성", () => {

--- a/src/components/Flex/Flex.tsx
+++ b/src/components/Flex/Flex.tsx
@@ -23,6 +23,8 @@ export interface FlexProps
   as?: As;
   /** 자식 간 간격 */
   gap?: Spacing;
+  /** 안쪽 여백 */
+  padding?: Spacing;
   /** ARIA 역할 */
   role?: AriaRole;
 }
@@ -54,6 +56,7 @@ export const Flex = ({
   justify = "start",
   align = "stretch",
   gap,
+  padding,
   className,
   ...rest
 }: FlexProps) => {
@@ -68,7 +71,7 @@ export const Flex = ({
           justify,
           align,
         }),
-        css({ gap }),
+        css({ gap, padding }),
         className,
       ),
       ...rest,

--- a/src/components/Grid/Grid.stories.tsx
+++ b/src/components/Grid/Grid.stories.tsx
@@ -45,6 +45,10 @@ export default {
       control: "select",
       options: [undefined, ...Object.keys(spacing || {})],
     },
+    padding: {
+      control: "select",
+      options: Object.keys(spacing || {}),
+    },
     areas: { control: false },
     className: { control: false },
   },
@@ -125,6 +129,24 @@ export const Gaps: Story = {
   ),
   argTypes: {
     gap: { control: false },
+  },
+};
+
+export const Padding: Story = {
+  render: (args) => (
+    <div className={grid({ gridTemplateColumns: "1fr", gap: "16" })}>
+      <div>
+        <h4>padding: 16</h4>
+        <Grid {...args} padding="16" />
+      </div>
+      <div>
+        <h4>padding: 32</h4>
+        <Grid {...args} padding="32" />
+      </div>
+    </div>
+  ),
+  argTypes: {
+    padding: { control: false },
   },
 };
 

--- a/src/components/Grid/Grid.test.tsx
+++ b/src/components/Grid/Grid.test.tsx
@@ -70,6 +70,21 @@ describe("Grid 클래스 토큰 및 스타일", () => {
     expect(screen.getByTestId(`grid-gap-${gap}`)).toHaveClass(`gap_${gap}`);
   });
 
+  const paddings = Object.keys(spacing || {}) as Spacing[];
+  test.each(paddings)(
+    `padding=%s 적용 시 알맞은 클래스가 적용된다`,
+    (padding) => {
+      render(
+        <Grid data-testid={`grid-padding-${padding}`} padding={padding}>
+          <GridItem>child</GridItem>
+        </Grid>,
+      );
+      expect(screen.getByTestId(`grid-padding-${padding}`)).toHaveClass(
+        `p_${padding}`,
+      );
+    },
+  );
+
   test("areas가 문자열로 전달되면 CSS 변수가 적용된다", () => {
     render(
       <Grid

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -45,6 +45,8 @@ export interface GridProps
   gridTemplateRows?: string;
   /** 자식 간 간격 */
   gap?: Spacing;
+  /** 안쪽 여백 */
+  padding?: Spacing;
   /** 영역 이름 (grid-template-areas, GridItem.gridArea와 함께 사용) */
   areas?: Areas;
   /** 자동 배치 흐름 (grid-auto-flow) */
@@ -73,6 +75,7 @@ export const Grid = ({
   gridTemplateColumns,
   gridTemplateRows,
   gap,
+  padding,
   areas,
   autoFlow = "row",
   justifyItems = "stretch",
@@ -97,6 +100,7 @@ export const Grid = ({
         }),
         css({
           gap,
+          padding,
           gridTemplateAreas: "var(--grid-template-areas, none)",
           gridTemplateColumns: "var(--grid-template-columns, none)",
           gridTemplateRows: "var(--grid-template-rows, none)",

--- a/src/components/HStack/HStack.stories.tsx
+++ b/src/components/HStack/HStack.stories.tsx
@@ -30,6 +30,7 @@ export default {
   argTypes: {
     children: { control: false },
     gap: { control: "select", options: Object.keys(spacing || {}) },
+    padding: { control: "select", options: Object.keys(spacing || {}) },
     className: { control: false },
     role: { control: "text" },
   },
@@ -72,6 +73,25 @@ export const Gaps: Story = {
   argTypes: {
     children: { control: false },
     gap: { control: false },
+  },
+};
+
+export const Padding: Story = {
+  render: (args) => (
+    <VStack gap="24">
+      <div>
+        <h4>padding: 16</h4>
+        <HStack {...args} padding="16" className={css({ width: "400" })} />
+      </div>
+      <div>
+        <h4>padding: 32</h4>
+        <HStack {...args} padding="32" className={css({ width: "400" })} />
+      </div>
+    </VStack>
+  ),
+  argTypes: {
+    children: { control: false },
+    padding: { control: false },
   },
 };
 

--- a/src/components/HStack/HStack.test.tsx
+++ b/src/components/HStack/HStack.test.tsx
@@ -92,6 +92,19 @@ describe("클래스 토큰 및 스타일", () => {
       expect(screen.getByTestId("gap").className).toMatch(className);
     },
   );
+
+  const paddings = Object.keys(spacing || {}) as Spacing[];
+  test.each(paddings.map((padding) => [padding, `p_${padding}`]))(
+    "padding=%s이면 %s 클래스가 적용된다",
+    (padding, className) => {
+      render(
+        <HStack data-testid="padding" padding={padding}>
+          <span>child</span>
+        </HStack>,
+      );
+      expect(screen.getByTestId("padding").className).toMatch(className);
+    },
+  );
 });
 
 describe("HStack 접근성", () => {

--- a/src/components/HStack/HStack.tsx
+++ b/src/components/HStack/HStack.tsx
@@ -44,6 +44,7 @@ export const HStack = ({
   align = "center",
   reversed = false,
   gap,
+  padding,
   className,
   ...rest
 }: HStackProps) => {
@@ -57,6 +58,7 @@ export const HStack = ({
       justify={justifyContent}
       align={alignContent}
       gap={gap}
+      padding={padding}
       className={className}
       {...rest}
     >

--- a/src/components/VStack/VStack.stories.tsx
+++ b/src/components/VStack/VStack.stories.tsx
@@ -30,6 +30,7 @@ export default {
   argTypes: {
     children: { control: false },
     gap: { control: "select", options: Object.keys(spacing || {}) },
+    padding: { control: "select", options: Object.keys(spacing || {}) },
     className: { control: false },
     role: { control: "text" },
   },
@@ -45,7 +46,7 @@ export default {
         <Item>아이템 2</Item>
       </>
     ),
-    className: css({ width: "120", height: "160" }),
+    className: css({ height: "160" }),
   },
 } satisfies Meta<typeof VStack>;
 
@@ -71,6 +72,24 @@ export const Gaps: Story = {
   ),
   argTypes: {
     gap: { control: false },
+  },
+};
+
+export const Padding: Story = {
+  render: (args) => (
+    <HStack gap="24">
+      <div>
+        <h4>padding: 16</h4>
+        <VStack {...args} padding="16" />
+      </div>
+      <div>
+        <h4>padding: 32</h4>
+        <VStack {...args} padding="32" />
+      </div>
+    </HStack>
+  ),
+  argTypes: {
+    padding: { control: false },
   },
 };
 

--- a/src/components/VStack/VStack.test.tsx
+++ b/src/components/VStack/VStack.test.tsx
@@ -98,6 +98,19 @@ describe("클래스 토큰 및 스타일", () => {
       expect(screen.getByTestId("gap").className).toMatch(className);
     },
   );
+
+  const paddings = Object.keys(spacing || {}) as Spacing[];
+  test.each(paddings.map((padding) => [padding, `p_${padding}`]))(
+    "padding=%s이면 %s 클래스가 적용된다",
+    (padding, className) => {
+      render(
+        <VStack data-testid="padding" padding={padding}>
+          <span>child</span>
+        </VStack>,
+      );
+      expect(screen.getByTestId("padding").className).toMatch(className);
+    },
+  );
 });
 
 describe("VStack 접근성", () => {

--- a/src/components/VStack/VStack.tsx
+++ b/src/components/VStack/VStack.tsx
@@ -47,6 +47,7 @@ export const VStack = ({
   align = "center",
   reversed = false,
   gap,
+  padding,
   className,
   ...rest
 }: VStackProps) => {
@@ -61,6 +62,7 @@ export const VStack = ({
       justify={justifyContent}
       align={alignContent}
       gap={gap}
+      padding={padding}
       className={className}
       {...rest}
     >


### PR DESCRIPTION
- Flex, Grid, VStack, HStack 컴포넌트에 padding prop을 추가하였습니다.
- story docs 양식 통일을 유지하였습니다. (https://github.com/DaleStudy/daleui/pull/952)

<!-- PR에 대해 알아야 하는 내용은 위키의 컨벤션을 확인해 주세요.
위키 - https://github.com/DaleStudy/daleui/wiki/Conventions -->

<!-- 무엇을 왜 변경했나요? (예: 접근성 개선을 위해 Button 컴포넌트에 disabled prop 추가) -->

## 테스팅
<img width="1143" height="680" alt="image" src="https://github.com/user-attachments/assets/02558c1c-f985-492c-9eee-468985c5747a" />
- Flex, Grid, VStack, HStack 컴포넌트에 padding 스토리 구동 확인하였습니다.


<!-- 변경 사항이 의도대로 동작하는지 어떻게 확인했나요? (예: 스크린샷 또는 비디오 첨부, 테스트 단계 설명) -->

## 체크 리스트

- [x] 코드 리뷰를 요청하기 전에 반드시 CI가 통과하는지 확인해주세요.
- [x] 컴포넌트나 스토리 변경이 있는 경우 PR에 ui 태그를 달아주세요.
  - [x] UI Tests를 통해 스냅샷 차이가 의도된 것인지 확인해주세요.
  - [x] UI Review를 통해 디자이너에게 리뷰를 요청하고 승인을 받으세요.

<!-- UI Review 및 UI Tests에 대한 내용은 상단 컨벤션 문서의 '7. PR리뷰 및 병합' 내용을 참고해 주세요. -->
