### PR TITLE
Checkbox/CheckboxGroup invalid 상태 텍스트 색상 수정 및 tone 정책 반영

### DIFF
--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -28,12 +28,8 @@ export const Tones: StoryObj<typeof Checkbox> = {
   render: (args) => {
     return (
       <div className={vstack({ gap: "16" })}>
-        <Checkbox {...args} label="브랜드 색조" tone="brand" />
-        <Checkbox {...args} label="중립 색조" tone="neutral" />
-        <Checkbox {...args} label="위험 색조" tone="danger" />
-        <Checkbox {...args} label="성공 색조" tone="success" />
-        <Checkbox {...args} label="경고 색조" tone="warning" />
-        <Checkbox {...args} label="정보 색조" tone="info" />
+        <Checkbox {...args} label="중립 톤" tone="neutral" />
+        <Checkbox {...args} label="브랜드 톤" tone="brand" />
       </div>
     );
   },
@@ -50,12 +46,10 @@ export const Disabled: StoryObj<typeof Checkbox> = {
       <div className={vstack({ gap: "16" })}>
         <Checkbox
           {...args}
-          label="비활성화 & 체크된 상태"
+          label="체크할 수 없습니다."
           disabled
           defaultChecked
         />
-        <Checkbox {...args} label="비활성화 & 체크되지 않은 상태" disabled />
-        <Checkbox {...args} label="활성화 상태" />
       </div>
     );
   },
@@ -84,6 +78,7 @@ export const Invalid: StoryObj<typeof Checkbox> = {
           errorMessage="필수 항목입니다."
         />
         <Checkbox {...args} label="정상 체크박스" />
+        <Checkbox {...args} label="체크해주세요." invalid />
       </div>
     );
   },

--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { userEvent } from "@testing-library/user-event";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, test, vi } from "vitest";
 import { Checkbox } from "./Checkbox";
 
@@ -106,7 +106,7 @@ describe("렌더링", () => {
   });
 
   test.each(["brand", "neutral"] as const)(
-    "%s tone을 올바르게 설정한다.",
+    "%s 톤을 올바르게 설정한다.",
     (tone) => {
       render(<Checkbox label={`${tone} tone`} tone={tone} />);
       expect(screen.getByRole("checkbox")).toHaveAttribute(

--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -108,7 +108,7 @@ describe("렌더링", () => {
   test.each(["brand", "neutral"] as const)(
     "%s 톤을 올바르게 설정한다.",
     (tone) => {
-      render(<Checkbox label={`${tone} tone`} tone={tone} />);
+      render(<Checkbox label={`${tone} 톤`} tone={tone} />);
       expect(screen.getByRole("checkbox")).toHaveAttribute(
         "data-test-tone",
         tone,

--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -82,6 +82,11 @@ describe("렌더링", () => {
     expect(checkbox).toHaveAttribute("data-test-tone", "brand");
   });
 
+  test("invalid 상태에서도 라벨 텍스트는 기본 색상을 유지한다.", () => {
+    render(<Checkbox label="테스트" invalid />);
+    expect(screen.getByText("테스트")).not.toHaveClass("c_fg.danger");
+  });
+
   test("모든 props를 함께 사용할 수 있다.", () => {
     const handleChange = vi.fn();
     render(
@@ -89,7 +94,7 @@ describe("렌더링", () => {
         label="전체 테스트"
         name="full-test"
         defaultChecked={true}
-        tone="success"
+        tone="neutral"
         onChange={handleChange}
       />,
     );
@@ -99,6 +104,17 @@ describe("렌더링", () => {
     expect(checkbox).toHaveAttribute("name", "full-test");
     expect(checkbox).toBeChecked();
   });
+
+  test.each(["brand", "neutral"] as const)(
+    "%s tone을 올바르게 설정한다.",
+    (tone) => {
+      render(<Checkbox label={`${tone} tone`} tone={tone} />);
+      expect(screen.getByRole("checkbox")).toHaveAttribute(
+        "data-test-tone",
+        tone,
+      );
+    },
+  );
 
   test("required가 true이면 필수 표시(*)가 렌더링된다.", () => {
     render(<Checkbox label="필수 체크박스" required />);

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -10,6 +10,8 @@ import { HelperText } from "../shared/HelperText";
 import { useHelperText } from "../shared/useHelperText";
 import type { FieldProps } from "../shared/types";
 
+type CheckboxTone = Extract<Tone, "brand" | "neutral">;
+
 export interface CheckboxProps extends Omit<FieldProps, "label"> {
   /** 라벨 내용 */
   label?: string;
@@ -19,9 +21,9 @@ export interface CheckboxProps extends Omit<FieldProps, "label"> {
   checked?: boolean;
   /** 비제어 모드 초기 체크 여부 */
   defaultChecked?: boolean;
-  /** 색조 */
-  tone?: Tone;
-  /** 체크 변경 핸들러 */
+  /** 체크박스의 색조 */
+  tone?: CheckboxTone;
+  /** 체크 상태 변경 시 호출되는 콜백 (controlled 모드) */
   onChange?: (checked: boolean) => void;
   /** 입력 요소 참조 */
   ref?: React.Ref<HTMLInputElement>;
@@ -189,39 +191,6 @@ const controlStyles = cva({
         },
         _focusVisible: {
           outlineColor: "border.brand.focus",
-        },
-      },
-      success: {
-        _before: {
-          backgroundColor: "fg.success",
-        },
-        _focusVisible: {
-          outlineColor: "border.success",
-        },
-      },
-      warning: {
-        _before: {
-          backgroundColor: "fg.warning",
-        },
-        _focusVisible: {
-          outlineColor: "border.warning",
-        },
-      },
-      info: {
-        _before: {
-          backgroundColor: "fg.info",
-        },
-        _focusVisible: {
-          outlineColor: "border.info",
-        },
-      },
-      danger: {
-        borderColor: "fg.danger",
-        _before: {
-          backgroundColor: "fg.danger",
-        },
-        _focusVisible: {
-          outlineColor: "border.danger",
         },
       },
       neutral: {

--- a/src/components/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -145,7 +145,7 @@ export const Invalid: Story = {
           name="valid-group"
           label="정상 체크박스 그룹"
           required
-          helperText="helper text"
+          helperText="과일을 선택해주세요."
         />
       </VStack>
     );

--- a/src/components/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -22,6 +22,7 @@ export default {
     tone: "brand",
     invalid: false,
     required: false,
+    helperText: undefined,
     children: (
       <>
         <CheckboxGroup.Item value="apple">사과</CheckboxGroup.Item>
@@ -40,12 +41,6 @@ export default {
 type Story = StoryObj<typeof CheckboxGroup>;
 
 export const Basic: Story = {};
-
-export const WithDefaultValue: Story = {
-  args: {
-    defaultValues: ["banana"],
-  },
-};
 
 export const Orientation: Story = {
   render: (args) => {
@@ -128,38 +123,6 @@ export const Tones: Story = {
           defaultValues={["apple"]}
           tone="brand"
         />
-
-        <CheckboxGroup
-          {...args}
-          name="danger-tone"
-          label="위험 색조 (Danger)"
-          defaultValues={["apple"]}
-          tone="danger"
-        />
-
-        <CheckboxGroup
-          {...args}
-          name="warning-tone"
-          label="경고 색조 (Warning)"
-          defaultValues={["apple"]}
-          tone="warning"
-        />
-
-        <CheckboxGroup
-          {...args}
-          name="success-tone"
-          label="성공 색조 (Success)"
-          defaultValues={["apple"]}
-          tone="success"
-        />
-
-        <CheckboxGroup
-          {...args}
-          name="info-tone"
-          label="정보 색조 (Info)"
-          defaultValues={["apple"]}
-          tone="info"
-        />
       </VStack>
     );
   },
@@ -172,7 +135,7 @@ export const Invalid: Story = {
         <CheckboxGroup
           {...args}
           name="invalid-group"
-          label="에러 상태 체크박스 그룹"
+          label="좋아하는 과일을 선택하세요"
           invalid
           errorMessage="하나 이상 선택해주세요."
         />
@@ -181,6 +144,8 @@ export const Invalid: Story = {
           {...args}
           name="valid-group"
           label="정상 체크박스 그룹"
+          required
+          helperText="helper text"
         />
       </VStack>
     );
@@ -238,12 +203,11 @@ const RequiredCheckboxGroup = (
       noValidate
       className={css({ w: "280px", spaceY: "16" })}
     >
-      <CheckboxGroup {...args} invalid={isInvalid} />
-      {isInvalid && (
-        <div className={css({ mt: "16", fontSize: "sm", color: "fg.danger" })}>
-          <p>필수 항목을 선택해주세요.</p>
-        </div>
-      )}
+      <CheckboxGroup
+        {...args}
+        helperText={isInvalid ? "필수 항목을 선택해주세요." : undefined}
+        invalid={isInvalid}
+      />
       <Button type="submit">제출</Button>
     </form>
   );

--- a/src/components/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -22,7 +22,6 @@ export default {
     tone: "brand",
     invalid: false,
     required: false,
-    helperText: undefined,
     children: (
       <>
         <CheckboxGroup.Item value="apple">사과</CheckboxGroup.Item>
@@ -34,6 +33,9 @@ export default {
   argTypes: {
     children: {
       control: false,
+    },
+    helperText: {
+      control: "text",
     },
   },
 } satisfies Meta<typeof CheckboxGroup>;

--- a/src/components/CheckboxGroup/CheckboxGroup.test.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.test.tsx
@@ -321,7 +321,7 @@ describe("CheckboxGroup", () => {
     expect(screen.getByText("도움말 텍스트")).toBeInTheDocument();
   });
 
-  test("invalid 상태에서도 옵션 텍스트는 기본 색상을 유지한다", () => {
+  test("invalid 상태에서도 option text는 기본 색상을 유지한다", () => {
     render(
       <CheckboxGroup
         name="test"

--- a/src/components/CheckboxGroup/CheckboxGroup.test.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.test.tsx
@@ -306,6 +306,36 @@ describe("CheckboxGroup", () => {
     expect(root).not.toBeNull();
     expect(root).toHaveAccessibleDescription("도움말입니다.");
   });
+
+  test("helperText가 있으면 invalid 여부와 관계없이 노출한다", () => {
+    render(
+      <CheckboxGroup
+        name="test"
+        label="Test Checkbox Group"
+        helperText="도움말 텍스트"
+      >
+        <CheckboxGroup.Item value="option1">Option 1</CheckboxGroup.Item>
+      </CheckboxGroup>,
+    );
+
+    expect(screen.getByText("도움말 텍스트")).toBeInTheDocument();
+  });
+
+  test("invalid 상태에서도 option text는 기본 색상을 유지한다", () => {
+    render(
+      <CheckboxGroup
+        name="test"
+        label="Test Checkbox Group"
+        invalid
+        helperText="에러 메시지"
+      >
+        <CheckboxGroup.Item value="option1">Option 1</CheckboxGroup.Item>
+      </CheckboxGroup>,
+    );
+
+    expect(screen.getByText("에러 메시지")).toBeInTheDocument();
+    expect(screen.getByText("Option 1")).not.toHaveClass("c_fg.danger");
+  });
 });
 
 describe("CheckboxGroup.Item", () => {
@@ -366,22 +396,18 @@ describe("CheckboxGroup.Item", () => {
     },
   );
 
-  test.each([
-    "neutral",
-    "brand",
-    "danger",
-    "warning",
-    "success",
-    "info",
-  ] as const)("%s 톤을 올바르게 렌더링한다", (tone) => {
-    render(
-      <CheckboxGroup name="test" label="Test Checkbox Group" tone={tone}>
-        <CheckboxGroup.Item value="option1">Option 1</CheckboxGroup.Item>
-      </CheckboxGroup>,
-    );
+  test.each(["neutral", "brand"] as const)(
+    "%s 톤을 올바르게 렌더링한다",
+    (tone) => {
+      render(
+        <CheckboxGroup name="test" label="Test Checkbox Group" tone={tone}>
+          <CheckboxGroup.Item value="option1">Option 1</CheckboxGroup.Item>
+        </CheckboxGroup>,
+      );
 
-    const checkbox = screen.getByLabelText("Option 1");
-    expect(checkbox).toBeInTheDocument();
-    expect(checkbox).toHaveAttribute("data-test-tone", tone);
-  });
+      const checkbox = screen.getByLabelText("Option 1");
+      expect(checkbox).toBeInTheDocument();
+      expect(checkbox).toHaveAttribute("data-test-tone", tone);
+    },
+  );
 });

--- a/src/components/CheckboxGroup/CheckboxGroup.test.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.test.tsx
@@ -321,7 +321,7 @@ describe("CheckboxGroup", () => {
     expect(screen.getByText("도움말 텍스트")).toBeInTheDocument();
   });
 
-  test("invalid 상태에서도 option text는 기본 색상을 유지한다", () => {
+  test("invalid 상태에서도 옵션 텍스트는 기본 색상을 유지한다", () => {
     render(
       <CheckboxGroup
         name="test"

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -12,9 +12,11 @@ import type { Tone } from "../../tokens/colors";
 import type { FieldProps } from "../shared/types";
 import { Checkbox } from "../Checkbox/Checkbox";
 
+type CheckboxGroupTone = Extract<Tone, "brand" | "neutral">;
+
 const CheckboxGroupContext = createContext<
   | ({
-      tone: Tone;
+      tone: CheckboxGroupTone;
       name: string;
       selectedValues: string[];
       onValueChange: (value: string, checked: boolean) => void;
@@ -44,11 +46,20 @@ export interface CheckboxGroupProps extends FieldProps {
   /** 배치 방향 (horizontal | vertical) */
   orientation?: "horizontal" | "vertical";
 
-  /** 색조 */
-  tone?: Tone;
+  /**
+   * 색상 강조를 지정합니다.
+   * @default "brand"
+   */
+  tone?: CheckboxGroupTone;
 
   /** 요소 참조 */
   ref?: Ref<HTMLDivElement>;
+
+  /**
+   * 그룹 하단에 표시할 보조 또는 에러 메시지입니다.
+   * @default undefined
+   */
+  helperText?: string;
 }
 
 /**


### PR DESCRIPTION
<!-- PR에 대해 알아야 하는 내용은 위키의 컨벤션을 확인해 주세요.
위키 - https://github.com/DaleStudy/daleui/wiki/Conventions -->

## 변경사항
<!-- 무엇을 왜 변경했나요? (예: 접근성 개선을 위해 Button 컴포넌트에 disabled prop 추가) -->

- invalid 상태에서도 라벨 텍스트는 기본 색상 유지
- CheckboxGroup에 helperText prop 추가
- invalid 상태에서만 에러 메시지와 아이콘 노출
- tone 타입을 brand, neutral로 제한

## 테스팅
<!-- 변경 사항이 의도대로 동작하는지 어떻게 확인했나요? (예: 스크린샷 또는 비디오 첨부, 테스트 단계 설명) -->
<img width="301" height="145" alt="Screenshot 2026-04-10 at 21 36 09" src="https://github.com/user-attachments/assets/4e8be795-b144-4724-a458-576040e1a0d6" />
<img width="307" height="177" alt="Screenshot 2026-04-10 at 21 33 43" src="https://github.com/user-attachments/assets/96a5e2e3-6f9a-43f9-bd68-62087c3affc8" />

- 기본 상태: 옵션 텍스트는 기본 색상으로 노출
- invalid 상태: 옵션 텍스트는 기본 색상을 유지하고, 하단 `helperText`로 에러 메시지 노출

## 체크 리스트

- [ ] 코드 리뷰를 요청하기 전에 반드시 CI가 통과하는지 확인해주세요.
- [ ] 컴포넌트나 스토리 변경이 있는 경우 PR에 ui 태그를 달아주세요.
  - [ ] UI Tests를 통해 스냅샷 차이가 의도된 것인지 확인해주세요.
  - [ ] UI Review를 통해 디자이너에게 리뷰를 요청하고 승인을 받으세요.

<!-- UI Review 및 UI Tests에 대한 내용은 상단 컨벤션 문서의 '7. PR리뷰 및 병합' 내용을 참고해 주세요. -->
