### PR TITLE
Checkbox label Prop type ReactNode -> string으로 변경

### DIFF
--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -9,19 +9,6 @@ describe("렌더링", () => {
     expect(screen.getByText("테스트 라벨")).toBeInTheDocument();
   });
 
-  test("ReactNode 라벨을 렌더링한다.", () => {
-    render(
-      <Checkbox
-        label={
-          <span data-testid="custom-label">
-            <strong>커스텀</strong> 라벨
-          </span>
-        }
-      />,
-    );
-    expect(screen.getByTestId("custom-label")).toBeInTheDocument();
-  });
-
   test("라벨이 없이도 렌더링된다.", () => {
     render(<Checkbox />);
     expect(screen.getByRole("checkbox")).toBeInTheDocument();

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -10,7 +10,7 @@ import type { FieldProps } from "../shared/types";
 
 export interface CheckboxProps extends FieldProps {
   /** 라벨 내용 */
-  label?: React.ReactNode;
+  label?: string;
   /** 폼 name */
   name?: string;
   /** 제어 모드 체크 여부 */

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -180,7 +180,7 @@ export interface CheckboxItemProps {
   value: string;
 
   /** 자식 요소 */
-  children?: ReactNode;
+  children?: string;
 
   /** 비활성화 여부 */
   disabled?: boolean;


### PR DESCRIPTION

<!-- PR에 대해 알아야 하는 내용은 위키의 컨벤션을 확인해 주세요.
위키 - https://github.com/DaleStudy/daleui/wiki/Conventions -->

<!-- 무엇을 왜 변경했나요? (예: 접근성 개선을 위해 Button 컴포넌트에 disabled prop 추가) -->

- 폼 컴포넌트의 통일성을 제공하기위해서 checkbox의 label을 string으로 제한합니다.

## 테스팅
<img width="1031" height="644" alt="image" src="https://github.com/user-attachments/assets/05f676c7-9ce1-43c4-8381-57a1f7212c3e" />

<!-- 변경 사항이 의도대로 동작하는지 어떻게 확인했나요? (예: 스크린샷 또는 비디오 첨부, 테스트 단계 설명) -->

## 체크 리스트

- [x] 코드 리뷰를 요청하기 전에 반드시 CI가 통과하는지 확인해주세요.
- [x] 컴포넌트나 스토리 변경이 있는 경우 PR에 ui 태그를 달아주세요.
  - [ ] UI Tests를 통해 스냅샷 차이가 의도된 것인지 확인해주세요.
  - [ ] UI Review를 통해 디자이너에게 리뷰를 요청하고 승인을 받으세요.

<!-- UI Review 및 UI Tests에 대한 내용은 상단 컨벤션 문서의 '7. PR리뷰 및 병합' 내용을 참고해 주세요. -->
