### PR TITLE
컴포넌트 이름 Radio에서 RadioGroupItem으로 변경

### DIFF
--- a/src/components/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { css } from "../../../styled-system/css";
 import { Button } from "../Button/Button";
 import { VStack } from "../VStack/VStack";
-import { CheckboxGroup, CheckboxItem } from "./CheckboxGroup";
+import { CheckboxGroup } from "./CheckboxGroup";
 
 export default {
   component: CheckboxGroup,
@@ -24,9 +24,9 @@ export default {
     required: false,
     children: (
       <>
-        <CheckboxItem value="apple">사과</CheckboxItem>
-        <CheckboxItem value="banana">바나나</CheckboxItem>
-        <CheckboxItem value="orange">오렌지</CheckboxItem>
+        <CheckboxGroup.Item value="apple">사과</CheckboxGroup.Item>
+        <CheckboxGroup.Item value="banana">바나나</CheckboxGroup.Item>
+        <CheckboxGroup.Item value="orange">오렌지</CheckboxGroup.Item>
       </>
     ),
   },
@@ -86,11 +86,11 @@ export const ItemDisabled: Story = {
           label="개별 아이템 비활성화 (선택됨)"
           defaultValues={["banana"]}
         >
-          <CheckboxItem value="apple">사과</CheckboxItem>
-          <CheckboxItem value="banana" disabled>
+          <CheckboxGroup.Item value="apple">사과</CheckboxGroup.Item>
+          <CheckboxGroup.Item value="banana" disabled>
             바나나 (disabled)
-          </CheckboxItem>
-          <CheckboxItem value="orange">오렌지</CheckboxItem>
+          </CheckboxGroup.Item>
+          <CheckboxGroup.Item value="orange">오렌지</CheckboxGroup.Item>
         </CheckboxGroup>
 
         <CheckboxGroup
@@ -98,11 +98,11 @@ export const ItemDisabled: Story = {
           label="개별 아이템 비활성화 (선택 안 됨)"
           defaultValues={["apple"]}
         >
-          <CheckboxItem value="apple">사과</CheckboxItem>
-          <CheckboxItem value="banana" disabled>
+          <CheckboxGroup.Item value="apple">사과</CheckboxGroup.Item>
+          <CheckboxGroup.Item value="banana" disabled>
             바나나 (disabled)
-          </CheckboxItem>
-          <CheckboxItem value="orange">오렌지</CheckboxItem>
+          </CheckboxGroup.Item>
+          <CheckboxGroup.Item value="orange">오렌지</CheckboxGroup.Item>
         </CheckboxGroup>
       </VStack>
     );

--- a/src/components/CheckboxGroup/CheckboxGroup.test.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.test.tsx
@@ -2,14 +2,14 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { describe, expect, test, vi } from "vitest";
-import { CheckboxGroup, CheckboxItem } from "./CheckboxGroup";
+import { CheckboxGroup } from "./CheckboxGroup";
 
 describe("CheckboxGroup", () => {
   test("라벨과 자식 요소들을 렌더링한다", () => {
     render(
       <CheckboxGroup name="test" label="Test Checkbox Group">
-        <CheckboxItem value="option1">Option 1</CheckboxItem>
-        <CheckboxItem value="option2">Option 2</CheckboxItem>
+        <CheckboxGroup.Item value="option1">Option 1</CheckboxGroup.Item>
+        <CheckboxGroup.Item value="option2">Option 2</CheckboxGroup.Item>
       </CheckboxGroup>,
     );
 
@@ -25,8 +25,8 @@ describe("CheckboxGroup", () => {
         label="Test Checkbox Group"
         defaultValues={["option2"]}
       >
-        <CheckboxItem value="option1">Option 1</CheckboxItem>
-        <CheckboxItem value="option2">Option 2</CheckboxItem>
+        <CheckboxGroup.Item value="option1">Option 1</CheckboxGroup.Item>
+        <CheckboxGroup.Item value="option2">Option 2</CheckboxGroup.Item>
       </CheckboxGroup>,
     );
 
@@ -40,8 +40,8 @@ describe("CheckboxGroup", () => {
   test("defaultValues가 제공되지 않으면 아무것도 선택하지 않는다", () => {
     render(
       <CheckboxGroup name="test" label="Test Checkbox Group">
-        <CheckboxItem value="option1">Option 1</CheckboxItem>
-        <CheckboxItem value="option2">Option 2</CheckboxItem>
+        <CheckboxGroup.Item value="option1">Option 1</CheckboxGroup.Item>
+        <CheckboxGroup.Item value="option2">Option 2</CheckboxGroup.Item>
       </CheckboxGroup>,
     );
 
@@ -59,9 +59,9 @@ describe("CheckboxGroup", () => {
         label="Test Checkbox Group"
         defaultValues={["option1", "option2"]}
       >
-        <CheckboxItem value="option1">Option 1</CheckboxItem>
-        <CheckboxItem value="option2">Option 2</CheckboxItem>
-        <CheckboxItem value="option3">Option 3</CheckboxItem>
+        <CheckboxGroup.Item value="option1">Option 1</CheckboxGroup.Item>
+        <CheckboxGroup.Item value="option2">Option 2</CheckboxGroup.Item>
+        <CheckboxGroup.Item value="option3">Option 3</CheckboxGroup.Item>
       </CheckboxGroup>,
     );
 
@@ -82,8 +82,8 @@ describe("CheckboxGroup", () => {
         defaultValues={["option1"]}
         values={["option2"]}
       >
-        <CheckboxItem value="option1">Option 1</CheckboxItem>
-        <CheckboxItem value="option2">Option 2</CheckboxItem>
+        <CheckboxGroup.Item value="option1">Option 1</CheckboxGroup.Item>
+        <CheckboxGroup.Item value="option2">Option 2</CheckboxGroup.Item>
       </CheckboxGroup>,
     );
 
@@ -97,8 +97,8 @@ describe("CheckboxGroup", () => {
   test("disabled가 true일 때 모든 체크박스를 비활성화한다", () => {
     render(
       <CheckboxGroup name="test" label="Test Checkbox Group" disabled>
-        <CheckboxItem value="option1">Option 1</CheckboxItem>
-        <CheckboxItem value="option2">Option 2</CheckboxItem>
+        <CheckboxGroup.Item value="option1">Option 1</CheckboxGroup.Item>
+        <CheckboxGroup.Item value="option2">Option 2</CheckboxGroup.Item>
       </CheckboxGroup>,
     );
 
@@ -109,7 +109,7 @@ describe("CheckboxGroup", () => {
     expect(option2).toBeDisabled();
   });
 
-  test("그룹 disabled가 하위 CheckboxItem의 disabled 스타일을 적용한다", () => {
+  test("그룹 disabled가 하위 CheckboxGroup.Item의 disabled 스타일을 적용한다", () => {
     render(
       <CheckboxGroup
         name="test"
@@ -117,8 +117,8 @@ describe("CheckboxGroup", () => {
         disabled
         defaultValues={["option1"]}
       >
-        <CheckboxItem value="option1">Option 1</CheckboxItem>
-        <CheckboxItem value="option2">Option 2</CheckboxItem>
+        <CheckboxGroup.Item value="option1">Option 1</CheckboxGroup.Item>
+        <CheckboxGroup.Item value="option2">Option 2</CheckboxGroup.Item>
       </CheckboxGroup>,
     );
 
@@ -132,10 +132,10 @@ describe("CheckboxGroup", () => {
   test("그룹 disabled와 개별 disabled가 모두 적용된다", () => {
     render(
       <CheckboxGroup name="test" label="Test Checkbox Group" disabled>
-        <CheckboxItem value="option1" disabled>
+        <CheckboxGroup.Item value="option1" disabled>
           Option 1
-        </CheckboxItem>
-        <CheckboxItem value="option2">Option 2</CheckboxItem>
+        </CheckboxGroup.Item>
+        <CheckboxGroup.Item value="option2">Option 2</CheckboxGroup.Item>
       </CheckboxGroup>,
     );
 
@@ -156,8 +156,8 @@ describe("CheckboxGroup", () => {
         label="Test Checkbox Group"
         onChange={onChange}
       >
-        <CheckboxItem value="option1">Option 1</CheckboxItem>
-        <CheckboxItem value="option2">Option 2</CheckboxItem>
+        <CheckboxGroup.Item value="option1">Option 1</CheckboxGroup.Item>
+        <CheckboxGroup.Item value="option2">Option 2</CheckboxGroup.Item>
       </CheckboxGroup>,
     );
 
@@ -172,9 +172,9 @@ describe("CheckboxGroup", () => {
 
     render(
       <CheckboxGroup name="test" label="Test Checkbox Group">
-        <CheckboxItem value="option1">Option 1</CheckboxItem>
-        <CheckboxItem value="option2">Option 2</CheckboxItem>
-        <CheckboxItem value="option3">Option 3</CheckboxItem>
+        <CheckboxGroup.Item value="option1">Option 1</CheckboxGroup.Item>
+        <CheckboxGroup.Item value="option2">Option 2</CheckboxGroup.Item>
+        <CheckboxGroup.Item value="option3">Option 3</CheckboxGroup.Item>
       </CheckboxGroup>,
     );
 
@@ -207,8 +207,8 @@ describe("CheckboxGroup", () => {
         label="Test Checkbox Group"
         defaultValues={["option1", "option2"]}
       >
-        <CheckboxItem value="option1">Option 1</CheckboxItem>
-        <CheckboxItem value="option2">Option 2</CheckboxItem>
+        <CheckboxGroup.Item value="option1">Option 1</CheckboxGroup.Item>
+        <CheckboxGroup.Item value="option2">Option 2</CheckboxGroup.Item>
       </CheckboxGroup>,
     );
 
@@ -242,8 +242,8 @@ describe("CheckboxGroup", () => {
             setSelectedValues(values);
           }}
         >
-          <CheckboxItem value="option1">Option 1</CheckboxItem>
-          <CheckboxItem value="option2">Option 2</CheckboxItem>
+          <CheckboxGroup.Item value="option1">Option 1</CheckboxGroup.Item>
+          <CheckboxGroup.Item value="option2">Option 2</CheckboxGroup.Item>
         </CheckboxGroup>
       );
     };
@@ -265,7 +265,7 @@ describe("CheckboxGroup", () => {
   test("required가 true일 때 라벨 옆에 별표를 표시한다", () => {
     render(
       <CheckboxGroup name="test" label="Test Checkbox Group" required>
-        <CheckboxItem value="option1">Option 1</CheckboxItem>
+        <CheckboxGroup.Item value="option1">Option 1</CheckboxGroup.Item>
       </CheckboxGroup>,
     );
 
@@ -280,7 +280,7 @@ describe("CheckboxGroup", () => {
   test("required가 true이고 disabled가 true일 때 별표 색상이 변경된다", () => {
     render(
       <CheckboxGroup name="test" label="Test Checkbox Group" required disabled>
-        <CheckboxItem value="option1">Option 1</CheckboxItem>
+        <CheckboxGroup.Item value="option1">Option 1</CheckboxGroup.Item>
       </CheckboxGroup>,
     );
 
@@ -295,7 +295,7 @@ describe("CheckboxGroup", () => {
   test("helperText가 있으면 하단에 표시하고 aria-describedby로 연결한다", () => {
     render(
       <CheckboxGroup name="test" label="Test Group" helperText="도움말입니다.">
-        <CheckboxItem value="option1">Option 1</CheckboxItem>
+        <CheckboxGroup.Item value="option1">Option 1</CheckboxGroup.Item>
       </CheckboxGroup>,
     );
     const help = screen.getByText("도움말입니다.");
@@ -308,14 +308,14 @@ describe("CheckboxGroup", () => {
   });
 });
 
-describe("CheckboxItem", () => {
+describe("CheckboxGroup.Item", () => {
   test("CheckboxGroup 없이 사용하면 에러를 던진다", () => {
-    const renderCheckboxItemAlone = () => {
-      render(<CheckboxItem value="option1">Option 1</CheckboxItem>);
+    const renderItemAlone = () => {
+      render(<CheckboxGroup.Item value="option1">Option 1</CheckboxGroup.Item>);
     };
 
-    expect(renderCheckboxItemAlone).toThrow(
-      "CheckboxItem 컴포넌트는 CheckboxGroup 내부에서만 사용해야 합니다.",
+    expect(renderItemAlone).toThrow(
+      "CheckboxGroup.Item 컴포넌트는 CheckboxGroup 내부에서만 사용해야 합니다.",
     );
   });
 
@@ -324,8 +324,8 @@ describe("CheckboxItem", () => {
 
     render(
       <CheckboxGroup name="test" label="Test Checkbox Group">
-        <CheckboxItem value="option1">Option 1</CheckboxItem>
-        <CheckboxItem value="option2">Option 2</CheckboxItem>
+        <CheckboxGroup.Item value="option1">Option 1</CheckboxGroup.Item>
+        <CheckboxGroup.Item value="option2">Option 2</CheckboxGroup.Item>
       </CheckboxGroup>,
     );
 
@@ -349,10 +349,10 @@ describe("CheckboxItem", () => {
     (optionName, isDisabled) => {
       render(
         <CheckboxGroup name="test" label="Test Checkbox Group">
-          <CheckboxItem value="option1">Option 1</CheckboxItem>
-          <CheckboxItem value="option2" disabled>
+          <CheckboxGroup.Item value="option1">Option 1</CheckboxGroup.Item>
+          <CheckboxGroup.Item value="option2" disabled>
             Option 2
-          </CheckboxItem>
+          </CheckboxGroup.Item>
         </CheckboxGroup>,
       );
 
@@ -376,7 +376,7 @@ describe("CheckboxItem", () => {
   ] as const)("%s 톤을 올바르게 렌더링한다", (tone) => {
     render(
       <CheckboxGroup name="test" label="Test Checkbox Group" tone={tone}>
-        <CheckboxItem value="option1">Option 1</CheckboxItem>
+        <CheckboxGroup.Item value="option1">Option 1</CheckboxGroup.Item>
       </CheckboxGroup>,
     );
 

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -59,12 +59,12 @@ export interface CheckboxGroupProps extends FieldProps {
  *
  * @example
  * <CheckboxGroup name="fruits" label="좋아하는 과일을 선택하세요 (옵션 선택)">
- *   <CheckboxItem value="apple">사과</CheckboxItem>
- *   <CheckboxItem value="banana">바나나</CheckboxItem>
- *   <CheckboxItem value="orange">오렌지</CheckboxItem>
+ *   <CheckboxGroup.Item value="apple">사과</CheckboxGroup.Item>
+ *   <CheckboxGroup.Item value="banana">바나나</CheckboxGroup.Item>
+ *   <CheckboxGroup.Item value="orange">오렌지</CheckboxGroup.Item>
  * </CheckboxGroup>
  */
-export function CheckboxGroup({
+function CheckboxGroupRoot({
   ref,
   children,
   name,
@@ -186,7 +186,7 @@ const checkboxGroupStyles = cva({
   },
 });
 
-export interface CheckboxItemProps {
+export interface CheckboxGroupItemProps {
   /** 옵션 값 */
   value: string;
 
@@ -197,16 +197,16 @@ export interface CheckboxItemProps {
   disabled?: boolean;
 }
 
-export function CheckboxItem({
+export function CheckboxGroupItem({
   value,
   children,
   disabled = false,
-}: CheckboxItemProps) {
+}: CheckboxGroupItemProps) {
   const context = useContext(CheckboxGroupContext);
 
   if (!context) {
     throw new Error(
-      "CheckboxItem 컴포넌트는 CheckboxGroup 내부에서만 사용해야 합니다.",
+      "CheckboxGroup.Item 컴포넌트는 CheckboxGroup 내부에서만 사용해야 합니다.",
     );
   }
 
@@ -238,3 +238,11 @@ export function CheckboxItem({
     />
   );
 }
+
+export const CheckboxGroup = Object.assign(CheckboxGroupRoot, {
+  /**
+   * CheckboxGroup의 개별 체크박스 항목입니다.
+   * CheckboxGroup 내부에서만 사용 가능하며, 그룹의 tone, disabled, invalid 상태를 자동으로 상속받습니다.
+   */
+  Item: CheckboxGroupItem,
+});

--- a/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { css } from "../../../styled-system/css";
-import { Radio, RadioGroup } from "./RadioGroup";
+import { RadioGroup } from "./RadioGroup";
 import { VStack } from "../VStack/VStack";
 
 export default {
@@ -17,9 +17,9 @@ export default {
     label: "좋아하는 과일을 선택하세요",
     children: (
       <>
-        <Radio value="apple">사과</Radio>
-        <Radio value="banana">바나나</Radio>
-        <Radio value="orange">오렌지</Radio>
+        <RadioGroup.Item value="apple">사과</RadioGroup.Item>
+        <RadioGroup.Item value="banana">바나나</RadioGroup.Item>
+        <RadioGroup.Item value="orange">오렌지</RadioGroup.Item>
       </>
     ),
   },
@@ -99,11 +99,11 @@ export const ItemDisabled: Story = {
           label="개별 아이템 비활성화 (선택됨)"
           defaultValue="banana"
         >
-          <Radio value="apple">사과</Radio>
-          <Radio value="banana" disabled>
+          <RadioGroup.Item value="apple">사과</RadioGroup.Item>
+          <RadioGroup.Item value="banana" disabled>
             바나나 (disabled)
-          </Radio>
-          <Radio value="orange">오렌지</Radio>
+          </RadioGroup.Item>
+          <RadioGroup.Item value="orange">오렌지</RadioGroup.Item>
         </RadioGroup>
 
         <RadioGroup
@@ -111,11 +111,11 @@ export const ItemDisabled: Story = {
           label="개별 아이템 비활성화 (선택 안 됨)"
           defaultValue="apple"
         >
-          <Radio value="apple">사과</Radio>
-          <Radio value="banana" disabled>
+          <RadioGroup.Item value="apple">사과</RadioGroup.Item>
+          <RadioGroup.Item value="banana" disabled>
             바나나 (disabled)
-          </Radio>
-          <Radio value="orange">오렌지</Radio>
+          </RadioGroup.Item>
+          <RadioGroup.Item value="orange">오렌지</RadioGroup.Item>
         </RadioGroup>
       </div>
     );

--- a/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/src/components/RadioGroup/RadioGroup.test.tsx
@@ -2,14 +2,14 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { describe, expect, test, vi } from "vitest";
-import { Radio, RadioGroup } from "./RadioGroup";
+import { RadioGroup } from "./RadioGroup";
 
 describe("RadioGroup", () => {
   test("라벨과 자식 요소들을 렌더링한다", () => {
     render(
       <RadioGroup name="test" label="Test Radio Group">
-        <Radio value="option1">Option 1</Radio>
-        <Radio value="option2">Option 2</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
+        <RadioGroup.Item value="option2">Option 2</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -21,8 +21,8 @@ describe("RadioGroup", () => {
   test("defaultValue가 제공되면 해당 값을 선택한다", () => {
     render(
       <RadioGroup name="test" label="Test Radio Group" defaultValue="option2">
-        <Radio value="option1">Option 1</Radio>
-        <Radio value="option2">Option 2</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
+        <RadioGroup.Item value="option2">Option 2</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -36,8 +36,8 @@ describe("RadioGroup", () => {
   test("defaultValue가 제공되지 않으면 아무것도 선택하지 않는다", () => {
     render(
       <RadioGroup name="test" label="Test Radio Group">
-        <Radio value="option1">Option 1</Radio>
-        <Radio value="option2">Option 2</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
+        <RadioGroup.Item value="option2">Option 2</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -56,8 +56,8 @@ describe("RadioGroup", () => {
         defaultValue="option1"
         value="option2"
       >
-        <Radio value="option1">Option 1</Radio>
-        <Radio value="option2">Option 2</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
+        <RadioGroup.Item value="option2">Option 2</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -71,8 +71,8 @@ describe("RadioGroup", () => {
   test("disabled가 true일 때 모든 라디오를 비활성화한다", () => {
     render(
       <RadioGroup name="test" label="Test Radio Group" disabled>
-        <Radio value="option1">Option 1</Radio>
-        <Radio value="option2">Option 2</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
+        <RadioGroup.Item value="option2">Option 2</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -83,7 +83,7 @@ describe("RadioGroup", () => {
     expect(option2).toBeDisabled();
   });
 
-  test("그룹 disabled가 하위 Radio의 disabled 스타일을 적용한다", () => {
+  test("그룹 disabled가 하위 RadioGroup.Item의 disabled 스타일을 적용한다", () => {
     render(
       <RadioGroup
         name="test"
@@ -91,8 +91,8 @@ describe("RadioGroup", () => {
         disabled
         defaultValue="option1"
       >
-        <Radio value="option1">Option 1</Radio>
-        <Radio value="option2">Option 2</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
+        <RadioGroup.Item value="option2">Option 2</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -113,10 +113,10 @@ describe("RadioGroup", () => {
   test("그룹 disabled와 개별 disabled가 모두 적용된다", () => {
     render(
       <RadioGroup name="test" label="Test Radio Group" disabled>
-        <Radio value="option1" disabled>
+        <RadioGroup.Item value="option1" disabled>
           Option 1
-        </Radio>
-        <Radio value="option2">Option 2</Radio>
+        </RadioGroup.Item>
+        <RadioGroup.Item value="option2">Option 2</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -134,8 +134,8 @@ describe("RadioGroup", () => {
 
     render(
       <RadioGroup name="test" label="Test Radio Group" onChange={onChange}>
-        <Radio value="option1">Option 1</Radio>
-        <Radio value="option2">Option 2</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
+        <RadioGroup.Item value="option2">Option 2</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -162,8 +162,8 @@ describe("RadioGroup", () => {
             setSelectedValue(value);
           }}
         >
-          <Radio value="option1">Option 1</Radio>
-          <Radio value="option2">Option 2</Radio>
+          <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
+          <RadioGroup.Item value="option2">Option 2</RadioGroup.Item>
         </RadioGroup>
       );
     };
@@ -183,14 +183,22 @@ describe("RadioGroup", () => {
   });
 });
 
-describe("Radio", () => {
+describe("RadioGroup.Item", () => {
+  test("RadioGroup 없이 사용하면 에러를 던진다", () => {
+    const renderItemAlone = () => {
+      render(<RadioGroup.Item value="option1">Option 1</RadioGroup.Item>);
+    };
+
+    expect(renderItemAlone).toThrow();
+  });
+
   test("다른 값들을 선택할 수 있다", async () => {
     const user = userEvent.setup();
 
     render(
       <RadioGroup name="test" label="Test Radio Group">
-        <Radio value="option1">Option 1</Radio>
-        <Radio value="option2">Option 2</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
+        <RadioGroup.Item value="option2">Option 2</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -214,10 +222,10 @@ describe("Radio", () => {
     (optionName, isDisabled) => {
       render(
         <RadioGroup name="test" label="Test Radio Group">
-          <Radio value="option1">Option 1</Radio>
-          <Radio value="option2" disabled>
+          <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
+          <RadioGroup.Item value="option2" disabled>
             Option 2
-          </Radio>
+          </RadioGroup.Item>
         </RadioGroup>,
       );
 
@@ -237,7 +245,7 @@ describe("Radio", () => {
   ] as const)("%s 톤을 올바르게 렌더링한다", (tone, className) => {
     render(
       <RadioGroup name="test" label="Test Radio Group" tone={tone}>
-        <Radio value="option1">Option 1</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -253,7 +261,7 @@ describe("RadioGroup hint", () => {
   test("hint가 제공되면 라벨 옆에 보조 텍스트가 렌더링된다", () => {
     render(
       <RadioGroup name="test" label="Test Radio Group" hint="(옵션 선택)">
-        <Radio value="option1">Option 1</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -263,7 +271,7 @@ describe("RadioGroup hint", () => {
   test("hint가 없으면 보조 텍스트가 렌더링되지 않는다", () => {
     render(
       <RadioGroup name="test" label="Test Radio Group">
-        <Radio value="option1">Option 1</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -278,7 +286,7 @@ describe("RadioGroup hint", () => {
         hint="(옵션 선택)"
         required
       >
-        <Radio value="option1">Option 1</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -293,7 +301,7 @@ describe("RadioGroup invalid", () => {
   test("invalid prop이 없을 때 aria-invalid='false'", () => {
     render(
       <RadioGroup name="test" label="Test Radio Group">
-        <Radio value="option1">Option 1</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -304,7 +312,7 @@ describe("RadioGroup invalid", () => {
   test("invalid={true}일 때 aria-invalid='true'", () => {
     render(
       <RadioGroup name="test" label="Test Radio Group" invalid>
-        <Radio value="option1">Option 1</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -315,7 +323,7 @@ describe("RadioGroup invalid", () => {
   test("invalid={false}일 때 aria-invalid='false'", () => {
     render(
       <RadioGroup name="test" label="Test Radio Group" invalid={false}>
-        <Radio value="option1">Option 1</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -326,7 +334,7 @@ describe("RadioGroup invalid", () => {
   test("invalid와 disabled를 함께 사용할 수 있다", () => {
     render(
       <RadioGroup name="test" label="Test Radio Group" invalid disabled>
-        <Radio value="option1">Option 1</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -346,8 +354,8 @@ describe("RadioGroup invalid", () => {
         invalid
         onChange={onChange}
       >
-        <Radio value="option1">Option 1</Radio>
-        <Radio value="option2">Option 2</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
+        <RadioGroup.Item value="option2">Option 2</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -361,7 +369,7 @@ describe("RadioGroup invalid", () => {
   test("invalid 상태일 때 danger 색상 스타일이 적용된다", () => {
     render(
       <RadioGroup name="test" label="Test Radio Group" invalid>
-        <Radio value="option1">Option 1</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -374,7 +382,7 @@ describe("RadioGroup required", () => {
   test("required={true}이면 필수 표시(*)가 렌더링된다", () => {
     render(
       <RadioGroup name="test" label="Test Radio Group" required>
-        <Radio value="option1">Option 1</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -386,7 +394,7 @@ describe("RadioGroup required", () => {
   test("required={false}이면 필수 표시가 없다", () => {
     render(
       <RadioGroup name="test" label="Test Radio Group" required={false}>
-        <Radio value="option1">Option 1</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -398,7 +406,7 @@ describe("RadioGroup required", () => {
   test("required prop이 없으면 필수 표시가 없다", () => {
     render(
       <RadioGroup name="test" label="Test Radio Group">
-        <Radio value="option1">Option 1</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -410,7 +418,7 @@ describe("RadioGroup required", () => {
   test("required와 disabled가 함께 있으면 비활성화 색상이 적용된다", () => {
     render(
       <RadioGroup name="test" label="Test Radio Group" required disabled>
-        <Radio value="option1">Option 1</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -421,7 +429,7 @@ describe("RadioGroup required", () => {
   test("required만 있으면 danger 색상이 적용된다", () => {
     render(
       <RadioGroup name="test" label="Test Radio Group" required>
-        <Radio value="option1">Option 1</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -432,7 +440,7 @@ describe("RadioGroup required", () => {
   test("required prop이 없을 때 aria-required='false'", () => {
     render(
       <RadioGroup name="test" label="Test Radio Group">
-        <Radio value="option1">Option 1</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -443,7 +451,7 @@ describe("RadioGroup required", () => {
   test("required={true}일 때 aria-required='true'", () => {
     render(
       <RadioGroup name="test" label="Test Radio Group" required>
-        <Radio value="option1">Option 1</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -454,7 +462,7 @@ describe("RadioGroup required", () => {
   test("required={false}일 때 aria-required='false'", () => {
     render(
       <RadioGroup name="test" label="Test Radio Group" required={false}>
-        <Radio value="option1">Option 1</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
       </RadioGroup>,
     );
 
@@ -471,7 +479,7 @@ describe("RadioGroup helperText", () => {
         label="Test Radio Group"
         helperText="필수 값을 선택해주세요."
       >
-        <Radio value="option1">Option 1</Radio>
+        <RadioGroup.Item value="option1">Option 1</RadioGroup.Item>
       </RadioGroup>,
     );
     const help = screen.getByText("필수 값을 선택해주세요.");

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -54,12 +54,12 @@ export interface RadioGroupProps extends FieldProps {
  *
  * @example
  * <RadioGroup name="fruits" label="좋아하는 과일을 선택하세요">
- *   <Radio value="apple">사과</Radio>
- *   <Radio value="banana">바나나</Radio>
- *   <Radio value="orange">오렌지</Radio>
+ *   <RadioGroup.Item value="apple">사과</RadioGroup.Item>
+ *   <RadioGroup.Item value="banana">바나나</RadioGroup.Item>
+ *   <RadioGroup.Item value="orange">오렌지</RadioGroup.Item>
  * </RadioGroup>
  */
-export function RadioGroup({
+function RadioGroupRoot({
   children,
   name,
   label,
@@ -157,7 +157,7 @@ const radioGroupStyles = cva({
   },
 });
 
-export interface RadioProps {
+export interface RadioGroupItemProps {
   /** 옵션 값 */
   value: string;
 
@@ -171,11 +171,18 @@ export interface RadioProps {
   ref?: React.Ref<HTMLInputElement>;
 }
 
-export function Radio({ value, children, disabled, ref }: RadioProps) {
+export function RadioGroupItem({
+  value,
+  children,
+  disabled,
+  ref,
+}: RadioGroupItemProps) {
   const context = useContext(RadioGroupContext);
 
   if (!context) {
-    throw new Error("Radio 컴포넌트는 RadioGroup 내부에서만 사용해야 합니다.");
+    throw new Error(
+      "RadioGroup.Item 컴포넌트는 RadioGroup 내부에서만 사용해야 합니다.",
+    );
   }
 
   const { tone, disabled: groupDisabled, invalid, required } = context;
@@ -371,4 +378,12 @@ const radioDotStyles = cva({
       },
     },
   },
+});
+
+export const RadioGroup = Object.assign(RadioGroupRoot, {
+  /**
+   * RadioGroup의 개별 라디오 항목입니다.
+   * RadioGroup 내부에서만 사용 가능하며, 그룹의 tone과 disabled 상태를 자동으로 상속받습니다.
+   */
+  Item: RadioGroupItem,
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,8 +21,8 @@ export { Checkbox, type CheckboxProps } from "./components/Checkbox/Checkbox";
 export {
   CheckboxGroup,
   type CheckboxGroupProps,
-  CheckboxItem,
-  type CheckboxItemProps,
+  CheckboxGroupItem,
+  type CheckboxGroupItemProps,
 } from "./components/CheckboxGroup/CheckboxGroup";
 export { Flex, type FlexProps } from "./components/Flex/Flex";
 export {
@@ -43,8 +43,8 @@ export {
 export {
   RadioGroup,
   type RadioGroupProps,
-  Radio,
-  type RadioProps,
+  RadioGroupItem,
+  type RadioGroupItemProps,
 } from "./components/RadioGroup/RadioGroup";
 export { Select, type SelectProps } from "./components/Select/Select";
 export { Tag, type TagProps } from "./components/Tag/Tag";


### PR DESCRIPTION
Closes #881

`Radio`를 `RadioGroupItem`으로, `CheckboxItem`을 `CheckboxGroupItem`으로 이름을 통일했습니다.

추가로 Compound Component 패턴을 적용하여 `RadioGroup.Item` / `CheckboxGroup.Item` 형태의 dot-notation으로 사용할 수 있도록 변경했습니다.

## 체크 리스트

- [x] 코드 리뷰를 요청하기 전에 반드시 CI가 통과하는지 확인해주세요.
- [ ] 컴포넌트나 스토리 변경이 있는 경우 PR에 ui 태그를 달아주세요.
  - [ ] UI Tests를 통해 스냅샷 차이가 의도된 것인지 확인해주세요.
  - [ ] UI Review를 통해 디자이너에게 리뷰를 요청하고 승인을 받으세요.

<!-- UI Review 및 UI Tests에 대한 내용은 상단 컨벤션 문서의 '7. PR리뷰 및 병합' 내용을 참고해 주세요. -->