### PR TITLE
Discord 회의 이벤트 자동 생성

### DIFF
--- a/.github/workflows/create-meeting-issue.yml
+++ b/.github/workflows/create-meeting-issue.yml
@@ -81,7 +81,7 @@ jobs:
         if: steps.meeting-info.outputs.type != 'skip'
         id: create-event # 다음 스텝에서 event_id 참조하기 위해 id 부여
         env:
-          DISCORD_MEETING_BOT_TOKEN: ${{ secrets.DISCORD_MEETING_BOT_TOKEN }}
+          DISCORD_DALEUI_MEETING_BOT_TOKEN: ${{ secrets.DISCORD_DALEUI_MEETING_BOT_TOKEN }}
           DISCORD_SERVER_ID: ${{ vars.DISCORD_SERVER_ID }}
           TITLE: ${{ steps.meeting-info.outputs.title }}
           ISSUE_URL: ${{ steps.create-issue.outputs.issue_url }}
@@ -98,7 +98,7 @@ jobs:
           # entity_metadata.location = 회의록 이슈 URL (이벤트 상세에서 클릭 가능)
           RESPONSE=$(curl -sf -X POST \
             "https://discord.com/api/v10/guilds/${DISCORD_SERVER_ID}/scheduled-events" \
-            -H "Authorization: Bot ${DISCORD_MEETING_BOT_TOKEN}" \
+            -H "Authorization: Bot ${DISCORD_DALEUI_MEETING_BOT_TOKEN}" \
             -H "Content-Type: application/json" \
             -d "{
               \"name\": \"${TITLE}\",
@@ -118,7 +118,7 @@ jobs:
       - name: Send channel announcement
         if: steps.meeting-info.outputs.type != 'skip'
         env:
-          DISCORD_MEETING_BOT_TOKEN: ${{ secrets.DISCORD_MEETING_BOT_TOKEN }}
+          DISCORD_DALEUI_MEETING_BOT_TOKEN: ${{ secrets.DISCORD_DALEUI_MEETING_BOT_TOKEN }}
           DISCORD_SERVER_ID: ${{ vars.DISCORD_SERVER_ID }}
           DISCORD_DALEUI_CHAT_CHANNEL_ID: ${{ vars.DISCORD_DALEUI_CHAT_CHANNEL_ID }}
           DISCORD_DALEUI_ROLE_ID: ${{ vars.DISCORD_DALEUI_ROLE_ID }}
@@ -131,7 +131,7 @@ jobs:
           # 디자인시스템-채팅 채널에 회의 일정 공지 및 RSVP 유도 메시지 전송
           curl -sf -X POST \
             "https://discord.com/api/v10/channels/${DISCORD_DALEUI_CHAT_CHANNEL_ID}/messages" \
-            -H "Authorization: Bot ${DISCORD_MEETING_BOT_TOKEN}" \
+            -H "Authorization: Bot ${DISCORD_DALEUI_MEETING_BOT_TOKEN}" \
             -H "Content-Type: application/json" \
             -d "{
               \"content\": \"<@&${DISCORD_DALEUI_ROLE_ID}>\n\n📅 **${TITLE}** 일정이 등록되었습니다.\n\n🇨🇦 금 8:30 PM (EDT) · 🇰🇷 토 9:30 AM (KST)\n📋 [회의록](${ISSUE_URL})\n\n[이벤트](${EVENT_LINK})에서 **Interested** 눌러 참석 여부를 알려주세요!\n불참 시에는 이 메시지 쓰레드에 남겨주세요 🙏\"

--- a/.github/workflows/create-meeting-issue.yml
+++ b/.github/workflows/create-meeting-issue.yml
@@ -81,7 +81,7 @@ jobs:
         if: steps.meeting-info.outputs.type != 'skip'
         id: create-event # 다음 스텝에서 event_id 참조하기 위해 id 부여
         env:
-          DISCORD_DALEUI_MEETING_BOT_TOKEN: ${{ secrets.DISCORD_DALEUI_MEETING_BOT_TOKEN }}
+          DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
           DISCORD_SERVER_ID: ${{ vars.DISCORD_SERVER_ID }}
           TITLE: ${{ steps.meeting-info.outputs.title }}
           ISSUE_URL: ${{ steps.create-issue.outputs.issue_url }}
@@ -100,7 +100,7 @@ jobs:
 
           RESPONSE=$(curl -sf --show-error -X POST \
             "https://discord.com/api/v10/guilds/${DISCORD_SERVER_ID}/scheduled-events" \
-            -H "Authorization: Bot ${DISCORD_DALEUI_MEETING_BOT_TOKEN}" \
+            -H "Authorization: Bot ${DISCORD_TOKEN}" \
             -H "Content-Type: application/json" \
             -d "{
               \"name\": \"${TITLE}\",
@@ -121,7 +121,7 @@ jobs:
       - name: Send channel announcement
         if: steps.meeting-info.outputs.type != 'skip'
         env:
-          DISCORD_DALEUI_MEETING_BOT_TOKEN: ${{ secrets.DISCORD_DALEUI_MEETING_BOT_TOKEN }}
+          DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
           DISCORD_SERVER_ID: ${{ vars.DISCORD_SERVER_ID }}
           DISCORD_DALEUI_CHAT_CHANNEL_ID: ${{ vars.DISCORD_DALEUI_CHAT_CHANNEL_ID }}
           DISCORD_DALEUI_ROLE_ID: ${{ vars.DISCORD_DALEUI_ROLE_ID }}
@@ -135,7 +135,7 @@ jobs:
           # 디자인시스템-채팅 채널에 회의 일정 공지 및 RSVP 유도 메시지 전송
           curl -sf --show-error -X POST \
             "https://discord.com/api/v10/channels/${DISCORD_DALEUI_CHAT_CHANNEL_ID}/messages" \
-            -H "Authorization: Bot ${DISCORD_DALEUI_MEETING_BOT_TOKEN}" \
+            -H "Authorization: Bot ${DISCORD_TOKEN}" \
             -H "Content-Type: application/json" \
             -d "{
               \"content\": \"<@&${DISCORD_DALEUI_ROLE_ID}>\n\n📅 **${TITLE}** 일정이 등록되었습니다.\n\n<t:${START_UNIX}:F> (<t:${START_UNIX}:R>)\n📋 [회의록](${ISSUE_URL})\n\n[이벤트](${EVENT_LINK})에서 **Interested** 눌러 참석 여부를 알려주세요!\n불참 시에는 이 메시지 쓰레드에 남겨주세요 🙏\"

--- a/.github/workflows/create-meeting-issue.yml
+++ b/.github/workflows/create-meeting-issue.yml
@@ -65,10 +65,74 @@ jobs:
 
       - name: Create GitHub issue
         if: steps.meeting-info.outputs.type != 'skip'
+        id: create-issue  # 다음 스텝에서 issue_url 참조하기 위해 id 부여
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TITLE: ${{ steps.meeting-info.outputs.title }}
         run: |
-          gh issue create \
+          # gh issue create는 생성된 이슈 URL을 stdout으로 출력함
+          ISSUE_URL=$(gh issue create \
             --title "$TITLE" \
-            --body-file /tmp/issue-body.md
+            --body-file /tmp/issue-body.md)
+          # GITHUB_OUTPUT에 저장해 다음 스텝에서 ${{ steps.create-issue.outputs.issue_url }}로 사용
+          echo "issue_url=$ISSUE_URL" >> $GITHUB_OUTPUT
+
+      - name: Create Discord scheduled event
+        if: steps.meeting-info.outputs.type != 'skip'
+        id: create-event  # 다음 스텝에서 event_id 참조하기 위해 id 부여
+        env:
+          DISCORD_MEETING_BOT_TOKEN: ${{ secrets.DISCORD_MEETING_BOT_TOKEN }}
+          DISCORD_SERVER_ID: ${{ vars.DISCORD_SERVER_ID }}
+          TITLE: ${{ steps.meeting-info.outputs.title }}
+          ISSUE_URL: ${{ steps.create-issue.outputs.issue_url }}
+        run: |
+          # 워크플로우는 현재 회의 종료 시점(토 01:30 UTC)에 실행됨
+          # Discord 이벤트는 7일 후 다음 회의(토 00:30 UTC = 금 8:30 PM EDT / 토 9:30 AM KST)로 설정
+          NEXT_SAT=$(date -d "+7 days" +%Y-%m-%d)
+          START_TIME="${NEXT_SAT}T00:30:00+00:00"  # 금 8:30 PM EDT / 토 9:30 AM KST
+          END_TIME="${NEXT_SAT}T01:30:00+00:00"    # 금 9:30 PM EDT / 토 10:30 AM KST (1시간 회의)
+
+          # Discord API: Scheduled Event 생성
+          # entity_type 3 = EXTERNAL (외부 링크 기반, RSVP 지원, 타임존별 시간 자동 표시)
+          # privacy_level 2 = GUILD_ONLY (서버 멤버만 볼 수 있음)
+          # entity_metadata.location = 회의록 이슈 URL (이벤트 상세에서 클릭 가능)
+          RESPONSE=$(curl -sf -X POST \
+            "https://discord.com/api/v10/guilds/${DISCORD_SERVER_ID}/scheduled-events" \
+            -H "Authorization: Bot ${DISCORD_MEETING_BOT_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"name\": \"${TITLE}\",
+              \"entity_type\": 3,
+              \"privacy_level\": 2,
+              \"scheduled_start_time\": \"${START_TIME}\",
+              \"scheduled_end_time\": \"${END_TIME}\",
+              \"entity_metadata\": {
+                \"location\": \"${ISSUE_URL}\"
+              }
+            }")
+
+          # 생성된 이벤트 ID 추출 → 채널 공지 스텝에서 이벤트 링크 생성에 사용
+          EVENT_ID=$(echo "$RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
+          echo "event_id=$EVENT_ID" >> $GITHUB_OUTPUT
+
+      - name: Send channel announcement
+        if: steps.meeting-info.outputs.type != 'skip'
+        env:
+          DISCORD_MEETING_BOT_TOKEN: ${{ secrets.DISCORD_MEETING_BOT_TOKEN }}
+          DISCORD_SERVER_ID: ${{ vars.DISCORD_SERVER_ID }}
+          DISCORD_DALEUI_CHAT_CHANNEL_ID: ${{ vars.DISCORD_DALEUI_CHAT_CHANNEL_ID }}
+          DISCORD_DALEUI_ROLE_ID: ${{ vars.DISCORD_DALEUI_ROLE_ID }}
+          TITLE: ${{ steps.meeting-info.outputs.title }}
+          ISSUE_URL: ${{ steps.create-issue.outputs.issue_url }}
+          EVENT_ID: ${{ steps.create-event.outputs.event_id }}
+        run: |
+          EVENT_LINK="https://discord.com/events/${DISCORD_SERVER_ID}/${EVENT_ID}"
+
+          # 디자인시스템-채팅 채널에 회의 일정 공지 및 RSVP 유도 메시지 전송
+          curl -sf -X POST \
+            "https://discord.com/api/v10/channels/${DISCORD_DALEUI_CHAT_CHANNEL_ID}/messages" \
+            -H "Authorization: Bot ${DISCORD_MEETING_BOT_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"content\": \"<@&${DISCORD_DALEUI_ROLE_ID}>\n\n📅 **${TITLE}** 일정이 등록되었습니다.\n🕗 금 8:30 PM EDT / 토 9:30 AM KST\n📋 회의록: ${ISSUE_URL}\n\n참석 여부를 이벤트에서 알려주세요 👉 ${EVENT_LINK}\"
+            }"

--- a/.github/workflows/create-meeting-issue.yml
+++ b/.github/workflows/create-meeting-issue.yml
@@ -96,7 +96,9 @@ jobs:
           # entity_type 3 = EXTERNAL (외부 링크 기반, RSVP 지원, 타임존별 시간 자동 표시)
           # privacy_level 2 = GUILD_ONLY (서버 멤버만 볼 수 있음)
           # entity_metadata.location = 회의록 이슈 URL (이벤트 상세에서 클릭 가능)
-          RESPONSE=$(curl -sf -X POST \
+          START_UNIX=$(date -d "${NEXT_SAT}T00:30:00+00:00" +%s)
+
+          RESPONSE=$(curl -sf --show-error -X POST \
             "https://discord.com/api/v10/guilds/${DISCORD_SERVER_ID}/scheduled-events" \
             -H "Authorization: Bot ${DISCORD_DALEUI_MEETING_BOT_TOKEN}" \
             -H "Content-Type: application/json" \
@@ -114,6 +116,7 @@ jobs:
           # 생성된 이벤트 ID 추출 → 채널 공지 스텝에서 이벤트 링크 생성에 사용
           EVENT_ID=$(echo "$RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
           echo "event_id=$EVENT_ID" >> $GITHUB_OUTPUT
+          echo "start_unix=$START_UNIX" >> $GITHUB_OUTPUT
 
       - name: Send channel announcement
         if: steps.meeting-info.outputs.type != 'skip'
@@ -125,14 +128,15 @@ jobs:
           TITLE: ${{ steps.meeting-info.outputs.title }}
           ISSUE_URL: ${{ steps.create-issue.outputs.issue_url }}
           EVENT_ID: ${{ steps.create-event.outputs.event_id }}
+          START_UNIX: ${{ steps.create-event.outputs.start_unix }}
         run: |
           EVENT_LINK="https://discord.com/events/${DISCORD_SERVER_ID}/${EVENT_ID}"
 
           # 디자인시스템-채팅 채널에 회의 일정 공지 및 RSVP 유도 메시지 전송
-          curl -sf -X POST \
+          curl -sf --show-error -X POST \
             "https://discord.com/api/v10/channels/${DISCORD_DALEUI_CHAT_CHANNEL_ID}/messages" \
             -H "Authorization: Bot ${DISCORD_DALEUI_MEETING_BOT_TOKEN}" \
             -H "Content-Type: application/json" \
             -d "{
-              \"content\": \"<@&${DISCORD_DALEUI_ROLE_ID}>\n\n📅 **${TITLE}** 일정이 등록되었습니다.\n\n🇨🇦 금 8:30 PM (EDT) · 🇰🇷 토 9:30 AM (KST)\n📋 [회의록](${ISSUE_URL})\n\n[이벤트](${EVENT_LINK})에서 **Interested** 눌러 참석 여부를 알려주세요!\n불참 시에는 이 메시지 쓰레드에 남겨주세요 🙏\"
+              \"content\": \"<@&${DISCORD_DALEUI_ROLE_ID}>\n\n📅 **${TITLE}** 일정이 등록되었습니다.\n\n<t:${START_UNIX}:F> (<t:${START_UNIX}:R>)\n📋 [회의록](${ISSUE_URL})\n\n[이벤트](${EVENT_LINK})에서 **Interested** 눌러 참석 여부를 알려주세요!\n불참 시에는 이 메시지 쓰레드에 남겨주세요 🙏\"
             }"

--- a/.github/workflows/create-meeting-issue.yml
+++ b/.github/workflows/create-meeting-issue.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Create GitHub issue
         if: steps.meeting-info.outputs.type != 'skip'
-        id: create-issue  # 다음 스텝에서 issue_url 참조하기 위해 id 부여
+        id: create-issue # 다음 스텝에서 issue_url 참조하기 위해 id 부여
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TITLE: ${{ steps.meeting-info.outputs.title }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Create Discord scheduled event
         if: steps.meeting-info.outputs.type != 'skip'
-        id: create-event  # 다음 스텝에서 event_id 참조하기 위해 id 부여
+        id: create-event # 다음 스텝에서 event_id 참조하기 위해 id 부여
         env:
           DISCORD_MEETING_BOT_TOKEN: ${{ secrets.DISCORD_MEETING_BOT_TOKEN }}
           DISCORD_SERVER_ID: ${{ vars.DISCORD_SERVER_ID }}

--- a/.github/workflows/create-meeting-issue.yml
+++ b/.github/workflows/create-meeting-issue.yml
@@ -134,5 +134,5 @@ jobs:
             -H "Authorization: Bot ${DISCORD_MEETING_BOT_TOKEN}" \
             -H "Content-Type: application/json" \
             -d "{
-              \"content\": \"<@&${DISCORD_DALEUI_ROLE_ID}>\n\n📅 **${TITLE}** 일정이 등록되었습니다.\n🕗 금 8:30 PM EDT / 토 9:30 AM KST\n📋 회의록: ${ISSUE_URL}\n\n참석 여부를 이벤트에서 알려주세요 👉 ${EVENT_LINK}\"
+              \"content\": \"<@&${DISCORD_DALEUI_ROLE_ID}>\n\n📅 **${TITLE}** 일정이 등록되었습니다.\n\n🇨🇦 금 8:30 PM (EDT) · 🇰🇷 토 9:30 AM (KST)\n📋 [회의록](${ISSUE_URL})\n\n[이벤트](${EVENT_LINK})에서 **Interested** 눌러 참석 여부를 알려주세요!\n불참 시에는 이 메시지 쓰레드에 남겨주세요 🙏\"
             }"


### PR DESCRIPTION
<!-- PR에 대해 알아야 하는 내용은 위키의 컨벤션을 확인해 주세요.
위키 - https://github.com/DaleStudy/daleui/wiki/Conventions -->

<!-- 무엇을 왜 변경했나요? (예: 접근성 개선을 위해 Button 컴포넌트에 disabled prop 추가) -->
기존에는 매주 회의 종료 후 회의록 생성까진 자동화를 하였으나 회의 이벤트는 Sesh를 통해 수동으로 Discord 이벤트를 생성하고 있었습니다.
이제 DaleUI Meeting Bot이 GitHub Actions와 Discord API를 통해 이 과정을 자동으로 처리합니다.

`create-meeting-issue.yml` 워크플로우에 두 스텝을 추가했습니다.

1. 회의록 이슈 생성 직후 Discord Scheduled Event 자동 생성
   - 이벤트 title: Sprint 번호 + 회의 타입 (중간/종료 회의)
   - 이벤트 location: 생성된 회의록 이슈 URL
   - 이벤트 시간: 다음 회의 일정 (금 8:30 PM EDT / 토 9:30 AM KST)

2. 디자인시스템-채팅 채널에 `@designsystem` 멘션과 함께 RSVP 유도 공지 자동 전송

| 구분 | 키 | 용도 |
|---|---|---|
| Secret | `DISCORD_DALEUI_MEETING_BOT_TOKEN` | Bot 인증 토큰 |
| Variable | `DISCORD_SERVER_ID` | 서버 ID |
| Variable | `DISCORD_DALEUI_CHAT_CHANNEL_ID` | 공지 채널 ID |
| Variable | `DISCORD_DALEUI_ROLE_ID` | 멘션 롤 ID |

## 테스팅
<!-- 변경 사항이 의도대로 동작하는지 어떻게 확인했나요? (예: 스크린샷 또는 비디오 첨부, 테스트 단계 설명) -->
개인 fork 레포에서 workflow_dispatch로 수동 실행 후 아래 세 가지를 확인했습니다.

**1. GitHub 이슈 생성**
- [x] 스프린트 번호/회의 타입이 올바르게 반영된 이슈 생성 확인

**2. Discord Scheduled Event 생성**
- [x] Events 탭에 7일 후 회의 일정으로 이벤트 생성 확인
- [x] location에 회의록 이슈 URL 포함 확인

**3. 채널 공지 메시지**
> 디자인시스템-채팅 채널에 아래와 같이 공지됩니다. (기존 Sesh 이벤트 대체)
```
@designsystem

📅 Sprint {number} 중간/종료 회의 일정이 등록되었습니다.

🇨🇦 금 8:30 PM (EDT) · 🇰🇷 토 9:30 AM (KST)
📋 회의록 (링크)

이벤트(링크)에서 Interested 눌러 참석 여부를 알려주세요!
불참 시에는 이 메시지 쓰레드에 남겨주세요 🙏
```


## 체크 리스트

- [x] 코드 리뷰를 요청하기 전에 반드시 CI가 통과하는지 확인해주세요.

<!-- UI Review 및 UI Tests에 대한 내용은 상단 컨벤션 문서의 '7. PR리뷰 및 병합' 내용을 참고해 주세요. -->