### PR TITLE
Skeleton 컴포넌트 및 브랜드 그라데이션(청록→보라) 추가

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -57,6 +57,21 @@ export default defineConfig({
             transform: "rotate(360deg)",
           },
         },
+        // 스켈레톤 - 중성 회색 펄스 (불투명도 깜빡임)
+        pulse: {
+          "0%, 100%": { opacity: "1" },
+          "50%": { opacity: "0.4" },
+        },
+        // 스켈레톤 - 중성 회색 웨이브 (::after 광택이 가로질러 흐름)
+        wave: {
+          "0%": { transform: "translateX(-100%)" },
+          "60%, 100%": { transform: "translateX(100%)" },
+        },
+        // 스켈레톤 - 브랜드 그라데이션 펄스 (그라데이션이 제자리에서 일렁임)
+        dalepulse: {
+          "0%, 100%": { backgroundPosition: "0% 50%" },
+          "50%": { backgroundPosition: "100% 50%" },
+        },
       },
       tokens: {
         borders,

--- a/src/components/Skeleton/Skeleton.stories.tsx
+++ b/src/components/Skeleton/Skeleton.stories.tsx
@@ -1,0 +1,313 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { css } from "../../../styled-system/css";
+import { Button } from "../Button/Button";
+import { Skeleton } from "./Skeleton";
+import type { SkeletonAnimation, SkeletonVariant } from "./Skeleton";
+
+interface SkeletonStoryArgs {
+  variant: SkeletonVariant;
+  animation: SkeletonAnimation;
+  width: string | number;
+  height: string | number;
+}
+
+const animations: SkeletonAnimation[] = [
+  "pulse",
+  "wave",
+  "dalepulse",
+  "dalewave",
+  false,
+];
+
+const row = css({ display: "flex", gap: "24", alignItems: "center" });
+const col = css({ display: "flex", flexDirection: "column", gap: "16" });
+const cell = css({ display: "flex", flexDirection: "column", gap: "8" });
+const label = css({
+  fontSize: "sm",
+  color: "fg.neutral",
+  fontFamily: "mono",
+});
+
+export default {
+  title: "Components/Skeleton",
+  parameters: {
+    layout: "centered",
+    // 애니메이션이 포함된 스토리의 스냅샷을 결정적으로 유지하기 위해 모션을 끝에서 멈춥니다.
+    chromatic: { pauseAnimationAtEnd: true },
+    docs: {
+      description: {
+        component: `
+콘텐츠가 로딩되는 동안 자리를 표시하는 플레이스홀더(스켈레톤) 컴포넌트입니다.
+
+- **variant**: \`text\`(기본) · \`circular\` · \`rectangular\` · \`rounded\`
+- **animation**: \`pulse\` · \`wave\`(중성 회색), \`dalepulse\` · \`dalewave\`(달레 브랜드 청록·보라를 옅게 씻어낸 톤), \`false\`(정적)
+- **loading**: \`false\`로 두면 실제 \`children\`이 렌더링됩니다. 자식을 전달하면 그 크기에 맞춰 레이아웃을 예약합니다.
+
+컴파운드 컴포넌트로 구성됩니다:
+- \`Skeleton\`: 기본 플레이스홀더 (variant, animation, width/height, loading)
+- \`Skeleton.Text\`: 여러 줄 텍스트 플레이스홀더 (lines, lastLineWidth)
+- \`Skeleton.Avatar\`: 원형 아바타 플레이스홀더 (size)
+
+### 접근성 및 모션 안내
+- 플레이스홀더는 \`aria-hidden\`으로 가려지고, 래퍼는 \`aria-busy\`로 로딩 상태를 알립니다.
+- 모든 애니메이션(\`dalewave\`/\`dalepulse\` 포함)은 \`prefers-reduced-motion: reduce\` 환경에서 자동으로 정적 채움으로 대체됩니다.
+        `,
+      },
+    },
+  },
+  args: {
+    variant: "text",
+    animation: "pulse",
+    width: "200px",
+    height: "",
+  },
+  argTypes: {
+    variant: {
+      control: "radio",
+      options: ["text", "circular", "rectangular", "rounded"],
+      description: "모양",
+    },
+    animation: {
+      control: "select",
+      options: animations,
+      description: "모션",
+    },
+    width: { control: "text", description: "너비 (숫자는 px)" },
+    height: { control: "text", description: "높이 (숫자는 px)" },
+  },
+  render: (args) => (
+    <Skeleton
+      variant={args.variant}
+      animation={args.animation}
+      width={args.width || undefined}
+      height={args.height || undefined}
+    />
+  ),
+} satisfies Meta<SkeletonStoryArgs>;
+
+export const Basic: StoryObj<SkeletonStoryArgs> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Controls 패널에서 variant, animation, width, height를 조정하여 테스트할 수 있습니다.",
+      },
+    },
+  },
+};
+
+export const Variants: StoryObj<SkeletonStoryArgs> = {
+  render: () => (
+    <div className={row}>
+      <div className={cell}>
+        <span className={label}>text</span>
+        <Skeleton variant="text" width="160px" />
+      </div>
+      <div className={cell}>
+        <span className={label}>circular</span>
+        <Skeleton variant="circular" width={56} height={56} />
+      </div>
+      <div className={cell}>
+        <span className={label}>rectangular</span>
+        <Skeleton variant="rectangular" width={120} height={56} />
+      </div>
+      <div className={cell}>
+        <span className={label}>rounded</span>
+        <Skeleton variant="rounded" width={120} height={56} />
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "네 가지 모양 변형입니다. `rectangular`는 직각 모서리(MUI 패리티), `rounded`는 `md` 반경, `text`는 둘러싼 글자 크기에 맞춰 높이가 자동 조절됩니다.",
+      },
+    },
+  },
+};
+
+export const Animations: StoryObj<SkeletonStoryArgs> = {
+  render: () => (
+    <div className={col}>
+      {animations.map((animation) => (
+        <div key={String(animation)} className={cell}>
+          <span className={label}>{String(animation)}</span>
+          <Skeleton
+            variant="rounded"
+            animation={animation}
+            width={240}
+            height={40}
+          />
+        </div>
+      ))}
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "다섯 가지 애니메이션입니다. `pulse`/`wave`는 중성 회색, `dalepulse`/`dalewave`는 달레 브랜드 색(청록·보라)을 옅게 씻어낸 톤의 모션(`dalewave`는 옅은 보라 바탕 위 옅은 청록 웨이브, `dalepulse`는 옅은 브랜드 그라데이션 일렁임), `false`는 정적 채움입니다. 회색 플레이버와 같은 낮은 대비로 플레이스홀더답게 보입니다.",
+      },
+    },
+  },
+};
+
+export const BrandGradient: StoryObj<SkeletonStoryArgs> = {
+  render: () => (
+    <div className={col}>
+      <div className={cell}>
+        <span className={label}>dalewave</span>
+        <Skeleton
+          variant="rounded"
+          animation="dalewave"
+          width={280}
+          height={48}
+        />
+      </div>
+      <div className={cell}>
+        <span className={label}>dalepulse</span>
+        <Skeleton
+          variant="rounded"
+          animation="dalepulse"
+          width={280}
+          height={48}
+        />
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "달레 전용 브랜드(청록·보라) 플레이버입니다. 브랜드 마크(`</>` 로고)와 같은 청록·보라 색을 옅게 씻어낸 톤(`bg.skeleton.brand`/`bg.skeleton.brandHighlight`, 테마 인지)으로 쓰며 `animation` 이름만으로 선택됩니다(별도의 `tone` prop 없음). 풀컬러 `--gradient-brand`가 아니라 회색 스켈레톤과 같은 낮은 대비의 톤이라 플레이스홀더답게 읽힙니다. `dalewave`는 옅은 보라 바탕 위로 옅은 청록 웨이브가 흐르고, `dalepulse`는 옅은 브랜드 그라데이션이 제자리에서 일렁입니다.",
+      },
+    },
+  },
+};
+
+export const Text: StoryObj<SkeletonStoryArgs> = {
+  render: () => (
+    <div className={css({ width: "320px" })}>
+      <Skeleton.Text lines={4} />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "여러 줄 텍스트 플레이스홀더입니다. 마지막 줄은 문단처럼 보이도록 좁아집니다(`lastLineWidth` 기본 60%).",
+      },
+    },
+  },
+};
+
+export const Avatar: StoryObj<SkeletonStoryArgs> = {
+  render: () => (
+    <div className={row}>
+      <Skeleton.Avatar size={32} />
+      <Skeleton.Avatar size={48} />
+      <Skeleton.Avatar size={64} />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "원형 아바타 플레이스홀더입니다. `size`로 지름을 지정합니다.",
+      },
+    },
+  },
+};
+
+export const MediaObject: StoryObj<SkeletonStoryArgs> = {
+  render: () => (
+    <div className={css({ display: "flex", gap: "16", width: "320px" })}>
+      <Skeleton.Avatar size={48} />
+      <div className={css({ flex: "1" })}>
+        <Skeleton.Text lines={3} />
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "아바타와 텍스트를 조합한 전형적인 카드/댓글 로딩 자리표시 예시입니다.",
+      },
+    },
+  },
+};
+
+function LoadingToggleDemo() {
+  const [loading, setLoading] = useState(true);
+  return (
+    <div
+      className={css({
+        display: "flex",
+        flexDirection: "column",
+        gap: "16",
+        width: "320px",
+      })}
+    >
+      <Button onClick={() => setLoading((value) => !value)}>
+        {loading ? "콘텐츠 보이기" : "다시 로딩"}
+      </Button>
+      <div className={css({ display: "flex", gap: "16" })}>
+        <Skeleton.Avatar size={48} loading={loading}>
+          <img
+            src="https://avatars.githubusercontent.com/u/52685259"
+            alt="DaleStudy"
+            width={48}
+            height={48}
+            className={css({ borderRadius: "full" })}
+          />
+        </Skeleton.Avatar>
+        <div className={css({ flex: "1" })}>
+          <Skeleton.Text lines={3} loading={loading}>
+            <p>
+              실제 콘텐츠가 여기에 표시됩니다. 로딩이 끝나면 스켈레톤이 실제
+              콘텐츠로 교체됩니다.
+            </p>
+          </Skeleton.Text>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const LoadingToggle: StoryObj<SkeletonStoryArgs> = {
+  render: () => <LoadingToggleDemo />,
+  parameters: {
+    // 인터랙션 데모이므로 Chromatic 스냅샷은 생략합니다.
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        story:
+          "`loading`을 토글하면 플레이스홀더가 실제 콘텐츠로 교체됩니다. 자식을 전달했기 때문에 로딩 중에는 자식 크기에 맞춰 레이아웃이 예약됩니다.",
+      },
+    },
+  },
+};
+
+export const ReducedMotion: StoryObj<SkeletonStoryArgs> = {
+  render: () => (
+    <div className={col}>
+      <Skeleton
+        variant="rounded"
+        animation="dalewave"
+        width={280}
+        height={40}
+      />
+      <Skeleton variant="rounded" animation="wave" width={280} height={40} />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "운영체제에서 '동작 줄이기'(`prefers-reduced-motion: reduce`)를 켜면 모든 애니메이션이 멈추고 정적 채움으로 대체됩니다. `dalewave`는 정적인 옅은 보라 채움으로, `dalepulse`는 정적인 옅은 브랜드 그라데이션으로, 회색 애니메이션은 정적인 회색으로 남습니다.",
+      },
+    },
+  },
+};

--- a/src/components/Skeleton/Skeleton.test.tsx
+++ b/src/components/Skeleton/Skeleton.test.tsx
@@ -1,0 +1,246 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { Skeleton } from "./Skeleton";
+
+/** 플레이스홀더(시각적 스켈레톤 박스)는 aria-hidden 으로 표시됩니다. */
+function getPlaceholder(container: HTMLElement) {
+  return container.querySelector('[aria-hidden="true"]');
+}
+
+function getPlaceholders(container: HTMLElement) {
+  return container.querySelectorAll('[aria-hidden="true"]');
+}
+
+/** 래퍼는 aria-busy 로 로딩 상태를 알립니다. */
+function getWrapper(container: HTMLElement) {
+  return container.querySelector("[aria-busy]");
+}
+
+/** 추론 모드에서 자식은 visibility:hidden(vis_hidden) 으로 감싸집니다. */
+function getHiddenChild(container: HTMLElement) {
+  return container.querySelector(".vis_hidden");
+}
+
+describe("Skeleton 모양 변형", () => {
+  test("text 변형은 sm 반경의 블록으로 렌더링됨", () => {
+    const { container } = render(<Skeleton variant="text" />);
+    const placeholder = getPlaceholder(container);
+    expect(placeholder).toHaveClass("bdr_sm");
+    expect(placeholder).toHaveClass("d_block");
+  });
+
+  test("circular 변형은 full 반경의 원형으로 렌더링됨", () => {
+    const { container } = render(<Skeleton variant="circular" width={40} />);
+    const placeholder = getPlaceholder(container);
+    expect(placeholder).toHaveClass("bdr_full");
+    expect(placeholder).toHaveClass("d_inline-block");
+  });
+
+  test("rectangular 변형은 직각 모서리(반경 0)로 렌더링됨", () => {
+    const { container } = render(
+      <Skeleton variant="rectangular" width={80} height={40} />,
+    );
+    expect(getPlaceholder(container)).toHaveClass("bdr_0");
+  });
+
+  test("rounded 변형은 md 반경으로 렌더링됨", () => {
+    const { container } = render(
+      <Skeleton variant="rounded" width={80} height={40} />,
+    );
+    expect(getPlaceholder(container)).toHaveClass("bdr_md");
+  });
+});
+
+describe("Skeleton 크기 지정", () => {
+  test("숫자 width/height는 px로 변환됨", () => {
+    const { container } = render(
+      <Skeleton variant="rectangular" width={120} height={32} />,
+    );
+    const placeholder = getPlaceholder(container) as HTMLElement;
+    expect(placeholder.style.width).toBe("120px");
+    expect(placeholder.style.height).toBe("32px");
+  });
+
+  test("문자열 width/height는 그대로 사용됨", () => {
+    const { container } = render(
+      <Skeleton variant="rectangular" width="50%" height="2rem" />,
+    );
+    const placeholder = getPlaceholder(container) as HTMLElement;
+    expect(placeholder.style.width).toBe("50%");
+    expect(placeholder.style.height).toBe("2rem");
+  });
+});
+
+describe("Skeleton 로딩 모델", () => {
+  test("loading=false이고 자식이 있으면 자식을 렌더링하고 플레이스홀더는 없음", () => {
+    const { container } = render(
+      <Skeleton loading={false}>
+        <span>실제 콘텐츠</span>
+      </Skeleton>,
+    );
+    expect(screen.getByText("실제 콘텐츠")).toBeInTheDocument();
+    expect(getPlaceholder(container)).not.toBeInTheDocument();
+  });
+
+  test("loading=true이고 자식이 있으면 플레이스홀더를 렌더링하고 자식은 숨김", () => {
+    const { container } = render(
+      <Skeleton loading={true}>
+        <span>실제 콘텐츠</span>
+      </Skeleton>,
+    );
+    const placeholder = getPlaceholder(container);
+    expect(placeholder).toBeInTheDocument();
+    // 자식은 레이아웃 예약을 위해 visibility:hidden 으로 감싸짐
+    const hiddenChild = getHiddenChild(container);
+    expect(hiddenChild).toHaveTextContent("실제 콘텐츠");
+    expect(hiddenChild).toHaveClass("vis_hidden");
+  });
+
+  test("자식이 없는 단독 스켈레톤은 loading 값과 무관하게 항상 플레이스홀더를 보여줌", () => {
+    const { container: loadingContainer } = render(<Skeleton />);
+    expect(getPlaceholder(loadingContainer)).toBeInTheDocument();
+
+    const { container: notLoadingContainer } = render(
+      <Skeleton loading={false} />,
+    );
+    expect(getPlaceholder(notLoadingContainer)).toBeInTheDocument();
+  });
+});
+
+describe("Skeleton 애니메이션", () => {
+  test("회색 애니메이션(pulse)은 bg.skeleton 채움과 pulse 키프레임을 사용함", () => {
+    const { container } = render(<Skeleton animation="pulse" />);
+    const className = getPlaceholder(container)?.className ?? "";
+    expect(className).toContain("bg-c_bg.skeleton");
+    expect(className).toContain("anim_pulse");
+    expect(className).not.toContain("gradient-brand");
+  });
+
+  test("wave 애니메이션은 회색 ::after 광택 오버레이를 사용함", () => {
+    const { container } = render(<Skeleton animation="wave" />);
+    const className = getPlaceholder(container)?.className ?? "";
+    expect(className).toContain("::after]:anim_wave");
+    expect(className).toContain("bg.skeleton.highlight");
+    expect(className).not.toContain("gradient-brand");
+    expect(className).not.toContain("skeleton.brand");
+  });
+
+  test("dalewave는 옅게 씻어낸 보라 바탕 위로 청록 웨이브(::after)가 흐름(풀컬러/미끄러지는 그라데이션 아님)", () => {
+    const { container } = render(<Skeleton animation="dalewave" />);
+    const className = getPlaceholder(container)?.className ?? "";
+    // 옅은 보라 바탕(bg.skeleton.brand) + 옅은 청록 광택(brandHighlight). 풀컬러 톤이 아닙니다.
+    expect(className).toContain("bg-c_bg.skeleton.brand");
+    expect(className).toContain("::after]:anim_wave");
+    expect(className).toContain("brandHighlight");
+    expect(className).not.toContain("gradient-brand");
+    expect(className).not.toContain("violet.9");
+  });
+
+  test("dalepulse는 옅게 씻어낸 브랜드 그라데이션을 쓰고 회색 광택(::after)은 쓰지 않음", () => {
+    const { container } = render(<Skeleton animation="dalepulse" />);
+    const className = getPlaceholder(container)?.className ?? "";
+    // 풀컬러 --gradient-brand가 아니라 옅은 스켈레톤 브랜드 토큰으로 그라데이션을 구성합니다.
+    expect(className).toContain("bg.skeleton.brandHighlight");
+    expect(className).toContain("anim_dalepulse");
+    expect(className).not.toContain("::after]:anim_wave");
+    expect(className).not.toContain("gradient-brand");
+  });
+});
+
+describe("Skeleton 접근성", () => {
+  test("플레이스홀더는 aria-hidden, 래퍼는 aria-busy를 가짐", () => {
+    const { container } = render(<Skeleton />);
+    const placeholder = getPlaceholder(container);
+    expect(placeholder).toHaveAttribute("aria-hidden", "true");
+
+    const wrapper = getWrapper(container);
+    expect(wrapper).toHaveAttribute("aria-busy", "true");
+  });
+
+  test("aria-busy는 loading 상태를 반영함", () => {
+    const { container } = render(
+      <Skeleton loading={false}>
+        <span>콘텐츠</span>
+      </Skeleton>,
+    );
+    expect(getWrapper(container)).toHaveAttribute("aria-busy", "false");
+  });
+});
+
+describe("Skeleton 모션 축소(prefers-reduced-motion)", () => {
+  test("모든 애니메이션은 prefers-reduced-motion 미디어 쿼리 뒤에 게이트되어 축소 시 정적 채움이 됨", () => {
+    // happy-dom 은 CSS 미디어 쿼리를 평가하지 않으므로, 애니메이션이 무조건 적용되지 않고
+    // prefers-reduced-motion 조건 뒤에 게이트되어 있음을 클래스 이름으로 검증합니다.
+    for (const animation of [
+      "pulse",
+      "wave",
+      "dalewave",
+      "dalepulse",
+    ] as const) {
+      const { container } = render(<Skeleton animation={animation} />);
+      const className = getPlaceholder(container)?.className ?? "";
+      expect(className).toContain("prefers-reduced-motion");
+    }
+  });
+
+  test("animation=false는 어떤 애니메이션도 적용하지 않음", () => {
+    const { container } = render(<Skeleton animation={false} />);
+    const className = getPlaceholder(container)?.className ?? "";
+    expect(className).not.toContain("anim_");
+    expect(className).not.toContain("prefers-reduced-motion");
+  });
+});
+
+describe("Skeleton.Text", () => {
+  test("lines 개수만큼 줄을 렌더링하고 마지막 줄을 좁힘", () => {
+    const { container } = render(<Skeleton.Text lines={3} />);
+    const placeholders = getPlaceholders(container);
+    expect(placeholders).toHaveLength(3);
+
+    expect((placeholders[0] as HTMLElement).style.width).toBe("100%");
+    expect((placeholders[1] as HTMLElement).style.width).toBe("100%");
+    expect((placeholders[2] as HTMLElement).style.width).toBe("60%");
+  });
+
+  test("한 줄이면 마지막 줄 너비 기본값은 100%", () => {
+    const { container } = render(<Skeleton.Text lines={1} />);
+    const placeholders = getPlaceholders(container);
+    expect(placeholders).toHaveLength(1);
+    expect((placeholders[0] as HTMLElement).style.width).toBe("100%");
+  });
+
+  test("lastLineWidth로 마지막 줄 너비를 지정할 수 있음", () => {
+    const { container } = render(
+      <Skeleton.Text lines={2} lastLineWidth="40%" />,
+    );
+    const placeholders = getPlaceholders(container);
+    expect((placeholders[1] as HTMLElement).style.width).toBe("40%");
+  });
+
+  test("loading=false이고 자식이 있으면 자식을 렌더링함", () => {
+    const { container } = render(
+      <Skeleton.Text loading={false}>
+        <p>실제 문단</p>
+      </Skeleton.Text>,
+    );
+    expect(screen.getByText("실제 문단")).toBeInTheDocument();
+    expect(getPlaceholder(container)).not.toBeInTheDocument();
+  });
+});
+
+describe("Skeleton.Avatar", () => {
+  test("size 크기의 원형 박스를 렌더링함", () => {
+    const { container } = render(<Skeleton.Avatar size={48} />);
+    const placeholder = getPlaceholder(container) as HTMLElement;
+    expect(placeholder).toHaveClass("bdr_full");
+    expect(placeholder.style.width).toBe("48px");
+    expect(placeholder.style.height).toBe("48px");
+  });
+
+  test("기본 size는 40px", () => {
+    const { container } = render(<Skeleton.Avatar />);
+    const placeholder = getPlaceholder(container) as HTMLElement;
+    expect(placeholder.style.width).toBe("40px");
+    expect(placeholder.style.height).toBe("40px");
+  });
+});

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -1,0 +1,334 @@
+import type { CSSProperties, HTMLAttributes, ReactNode, Ref } from "react";
+import { css, cva, cx } from "../../../styled-system/css";
+import { VStack } from "../VStack/VStack";
+
+/** 스켈레톤의 모양 변형 */
+export type SkeletonVariant = "text" | "circular" | "rectangular" | "rounded";
+
+/**
+ * 스켈레톤의 애니메이션.
+ * `pulse`/`wave`는 중성 회색이고, `dalepulse`/`dalewave`는 달레 브랜드(청록·보라)를 옅게 씻어낸
+ * 톤의 모션입니다(스켈레톤답게 낮은 대비). `dalewave`는 옅은 보라 바탕 위로 청록 웨이브가 흐르고,
+ * `dalepulse`는 옅은 브랜드 그라데이션이 일렁입니다. `false`는 애니메이션 없이 정적인 회색으로 채웁니다.
+ */
+export type SkeletonAnimation =
+  | "pulse"
+  | "wave"
+  | "dalepulse"
+  | "dalewave"
+  | false;
+
+export interface SkeletonProps extends Omit<
+  HTMLAttributes<HTMLElement>,
+  "style"
+> {
+  /**
+   * 모양.
+   * - `text`: 둘러싼 글자 크기에 맞춰 높이가 자동 조절됩니다(기본값).
+   * - `circular`: 정원형. `width`/`height`(또는 `Skeleton.Avatar`의 `size`)로 크기를 지정합니다.
+   * - `rectangular`: 직각 모서리(MUI와 동일).
+   * - `rounded`: `md` 반경의 둥근 모서리.
+   */
+  variant?: SkeletonVariant;
+  /**
+   * 모션.
+   * `pulse`/`wave`는 중성 회색, `dalepulse`/`dalewave`는 브랜드 그라데이션, `false`는 정적입니다.
+   * 모든 애니메이션은 `prefers-reduced-motion: reduce` 환경에서 자동으로 정적 채움으로 대체됩니다.
+   */
+  animation?: SkeletonAnimation;
+  /** 너비. 숫자는 `px`로, 문자열은 그대로 사용합니다. */
+  width?: string | number;
+  /** 높이. 숫자는 `px`로, 문자열은 그대로 사용합니다. */
+  height?: string | number;
+  /**
+   * 로딩 여부.
+   * `true`(기본값)이면 플레이스홀더를 보여주고, `false`이면 실제 `children`을 렌더링합니다.
+   */
+  loading?: boolean;
+  /**
+   * 자식 요소.
+   * `loading`이 `true`이고 자식이 있으면, 플레이스홀더가 자식의 박스 크기에 맞춰지고
+   * 자식은 `visibility: hidden`으로 숨겨져 레이아웃을 그대로 예약합니다.
+   */
+  children?: ReactNode;
+  /** 요소 참조 */
+  ref?: Ref<HTMLElement>;
+}
+
+function toCssSize(value?: string | number): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return typeof value === "number" ? `${value}px` : value;
+}
+
+function SkeletonRoot({
+  ref,
+  variant = "text",
+  animation = "pulse",
+  width,
+  height,
+  loading = true,
+  children,
+  className,
+  ...rest
+}: SkeletonProps) {
+  const hasChildren = children !== undefined && children !== null;
+
+  // loading이 false이고 교체할 자식이 있으면 플레이스홀더 없이 실제 자식을 렌더링합니다.
+  // 자식이 없는 단독 스켈레톤은 loading 값과 무관하게 항상 플레이스홀더를 보여줍니다.
+  if (!loading && hasChildren) {
+    return (
+      <span ref={ref} aria-busy={false} className={className} {...rest}>
+        {children}
+      </span>
+    );
+  }
+
+  const style: CSSProperties = {
+    width: toCssSize(width),
+    height: toCssSize(height),
+  };
+
+  return (
+    <span ref={ref} aria-busy={true} className={className} {...rest}>
+      <span
+        aria-hidden="true"
+        style={style}
+        className={cx(
+          placeholderStyles({
+            variant,
+            animation: animation === false ? "none" : animation,
+          }),
+          hasChildren && inferredStyles,
+        )}
+      >
+        {hasChildren ? (
+          <span className={hiddenChildStyles}>{children}</span>
+        ) : null}
+      </span>
+    </span>
+  );
+}
+
+export interface SkeletonTextProps extends Omit<
+  HTMLAttributes<HTMLElement>,
+  "style"
+> {
+  /** 줄 수 */
+  lines?: number;
+  /** 마지막 줄의 너비. 기본값은 `lines > 1`일 때 `"60%"`, 그 외에는 `"100%"`입니다. */
+  lastLineWidth?: string;
+  /** 모션. `Skeleton`과 동일한 값입니다. */
+  animation?: SkeletonAnimation;
+  /** 로딩 여부 */
+  loading?: boolean;
+  /** 자식 요소. `loading`이 `false`일 때 줄 대신 렌더링됩니다. */
+  children?: ReactNode;
+  /** 요소 참조 */
+  ref?: Ref<HTMLElement>;
+}
+
+function SkeletonText({
+  ref,
+  lines = 1,
+  lastLineWidth,
+  animation = "pulse",
+  loading = true,
+  children,
+  className,
+  ...rest
+}: SkeletonTextProps) {
+  const hasChildren = children !== undefined && children !== null;
+
+  // loading이 false이고 자식이 있으면 줄 대신 실제 자식을 렌더링합니다.
+  if (!loading && hasChildren) {
+    return (
+      <span ref={ref} aria-busy={false} className={className} {...rest}>
+        {children}
+      </span>
+    );
+  }
+
+  const resolvedLastLineWidth = lastLineWidth ?? (lines > 1 ? "60%" : "100%");
+
+  return (
+    <VStack
+      ref={ref}
+      as="span"
+      align="stretch"
+      gap="4"
+      aria-busy={true}
+      className={className}
+      {...rest}
+    >
+      {Array.from({ length: lines }, (_, index) => (
+        <SkeletonRoot
+          key={index}
+          variant="text"
+          animation={animation}
+          width={index === lines - 1 ? resolvedLastLineWidth : "100%"}
+        />
+      ))}
+    </VStack>
+  );
+}
+
+export interface SkeletonAvatarProps extends Omit<
+  HTMLAttributes<HTMLElement>,
+  "style"
+> {
+  /** 지름. 숫자는 `px`로, 문자열은 그대로 사용합니다. */
+  size?: string | number;
+  /** 모션. `Skeleton`과 동일한 값입니다. */
+  animation?: SkeletonAnimation;
+  /** 로딩 여부 */
+  loading?: boolean;
+  /** 자식 요소 */
+  children?: ReactNode;
+  /** 요소 참조 */
+  ref?: Ref<HTMLElement>;
+}
+
+function SkeletonAvatar({
+  ref,
+  size = 40,
+  animation = "pulse",
+  loading = true,
+  children,
+  className,
+  ...rest
+}: SkeletonAvatarProps) {
+  return (
+    <SkeletonRoot
+      ref={ref}
+      variant="circular"
+      width={size}
+      height={size}
+      animation={animation}
+      loading={loading}
+      className={className}
+      {...rest}
+    >
+      {children}
+    </SkeletonRoot>
+  );
+}
+
+// 자식이 있을 때(추론 모드): 플레이스홀더를 자식 박스 크기에 맞춥니다.
+const inferredStyles = css({
+  display: "inline-block",
+  width: "fit-content",
+  height: "auto",
+  transform: "none",
+});
+
+// 추론 모드에서 레이아웃만 예약하기 위해 자식을 시각적으로 숨깁니다.
+const hiddenChildStyles = css({
+  visibility: "hidden",
+});
+
+const placeholderStyles = cva({
+  base: {
+    backgroundColor: "bg.skeleton",
+    position: "relative",
+    overflow: "hidden",
+  },
+  variants: {
+    variant: {
+      text: {
+        display: "block",
+        width: "100%",
+        height: "1.2em",
+        borderRadius: "sm",
+        // 글자처럼 보이도록 세로로 눌러 표현합니다(레이아웃 높이는 1.2em을 유지).
+        transform: "scale(1, 0.6)",
+        transformOrigin: "0 60%",
+      },
+      circular: {
+        display: "inline-block",
+        borderRadius: "full",
+      },
+      rectangular: {
+        display: "inline-block",
+        borderRadius: "0",
+      },
+      rounded: {
+        display: "inline-block",
+        borderRadius: "md",
+      },
+    },
+    animation: {
+      none: {},
+      pulse: {
+        // prefers-reduced-motion 환경에서는 애니메이션을 적용하지 않아 정적 채움이 됩니다.
+        "@media (prefers-reduced-motion: no-preference)": {
+          animation: "pulse 1.6s ease-in-out infinite",
+        },
+      },
+      wave: {
+        "@media (prefers-reduced-motion: no-preference)": {
+          "&::after": {
+            content: '""',
+            position: "absolute",
+            inset: "0",
+            transform: "translateX(-100%)",
+            backgroundImage:
+              "linear-gradient(90deg, transparent, token(colors.bg.skeleton.highlight), transparent)",
+            animation: "wave 1.6s linear infinite",
+          },
+        },
+      },
+      // 옅게 씻어낸 보라 바탕 위로 청록 웨이브가 흐릅니다(회색 wave의 브랜드 버전).
+      // 풀컬러 브랜드 색이 아니라 회색 스켈레톤과 같은 무게의 옅은 톤을 써서 플레이스홀더처럼 보입니다.
+      dalewave: {
+        backgroundColor: "bg.skeleton.brand",
+        "@media (prefers-reduced-motion: no-preference)": {
+          "&::after": {
+            content: '""',
+            position: "absolute",
+            inset: "0",
+            transform: "translateX(-100%)",
+            backgroundImage:
+              "linear-gradient(90deg, transparent, token(colors.bg.skeleton.brandHighlight), transparent)",
+            animation: "wave 1.6s linear infinite",
+          },
+        },
+      },
+      // 옅게 씻어낸 브랜드 그라데이션(청록 -> 보라)이 제자리에서 일렁입니다.
+      dalepulse: {
+        backgroundImage:
+          "linear-gradient(135deg, token(colors.bg.skeleton.brandHighlight), token(colors.bg.skeleton.brand))",
+        backgroundSize: "200% 100%",
+        backgroundRepeat: "no-repeat",
+        "@media (prefers-reduced-motion: no-preference)": {
+          animation: "dalepulse 2s ease-in-out infinite",
+        },
+      },
+    },
+  },
+  defaultVariants: {
+    variant: "text",
+    animation: "pulse",
+  },
+});
+
+/**
+ * 콘텐츠가 로딩되는 동안 자리를 표시하는 플레이스홀더(스켈레톤) 컴포넌트입니다.
+ *
+ * - `variant`로 모양(텍스트/원형/직사각형/둥근 사각형)을 고릅니다.
+ * - `animation`으로 모션을 고릅니다. `pulse`/`wave`는 중성 회색, `dalepulse`/`dalewave`는 달레 브랜드(청록·보라) 모션입니다.
+ * - `loading={false}`로 실제 콘텐츠로 교체할 수 있고, 자식을 전달하면 그 크기에 맞춰 레이아웃을 예약합니다.
+ * - 플레이스홀더는 `aria-hidden`으로 가려지고, 래퍼는 `aria-busy`로 로딩 상태를 알립니다.
+ * - 모든 애니메이션은 `prefers-reduced-motion: reduce` 환경에서 정적 채움으로 대체됩니다.
+ */
+export const Skeleton = Object.assign(SkeletonRoot, {
+  /**
+   * 여러 줄의 텍스트 플레이스홀더입니다. `lines`로 줄 수를, `lastLineWidth`로 마지막 줄 너비를 조절합니다.
+   */
+  Text: SkeletonText,
+  /**
+   * 원형 아바타 플레이스홀더입니다. `size`로 지름을 지정합니다.
+   */
+  Avatar: SkeletonAvatar,
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,14 @@ export {
   type RadioGroupItemProps,
 } from "./components/RadioGroup/RadioGroup";
 export { Select, type SelectProps } from "./components/Select/Select";
+export {
+  Skeleton,
+  type SkeletonProps,
+  type SkeletonTextProps,
+  type SkeletonAvatarProps,
+  type SkeletonVariant,
+  type SkeletonAnimation,
+} from "./components/Skeleton/Skeleton";
 export { Tag, type TagProps } from "./components/Tag/Tag";
 export { Text, type TextProps } from "./components/Text/Text";
 export {

--- a/src/styles/globalCss.ts
+++ b/src/styles/globalCss.ts
@@ -3,6 +3,10 @@ import { defineGlobalStyles } from "@pandacss/dev";
 export const globalCss = defineGlobalStyles({
   ":root": {
     "--global-font-body": "var(--fonts-sans)",
+    // 달레 브랜드 그라데이션 (청록 -> 보라). 브랜드 마크(</> 로고)와 동일하게 청록(teal.9)과
+    // 보라(violet.9) 브랜드 폴을 고정값으로 사용하므로 라이트/다크 테마에서 동일합니다.
+    "--gradient-brand":
+      "linear-gradient(135deg, var(--colors-teal-9), var(--colors-violet-9))",
   },
   body: {
     backgroundColor: "appBg",

--- a/src/tokens/colors.ts
+++ b/src/tokens/colors.ts
@@ -70,6 +70,24 @@ export const semanticColors: SemanticTokens["colors"] = {
       value: { base: "{colors.amber.1}", _dark: "{colors.darkAmber.1}" },
     },
     info: { value: { base: "{colors.blue.2}", _dark: "{colors.darkBlue.3}" } },
+    skeleton: {
+      // 스켈레톤 플레이스홀더의 기본 채움색
+      DEFAULT: {
+        value: { base: "{colors.slate.3}", _dark: "{colors.darkSage.4}" },
+      },
+      // wave 애니메이션이 훑고 지나가는 밝은 강조색 (두 테마 모두 기본색보다 밝음)
+      highlight: {
+        value: { base: "{colors.slate.1}", _dark: "{colors.darkSage.6}" },
+      },
+      // 브랜드 플레이버(dale*)의 옅게 씻어낸 보라 바탕. 회색 스켈레톤과 같은 무게감을 유지합니다.
+      brand: {
+        value: { base: "{colors.violet.4}", _dark: "{colors.darkViolet.4}" },
+      },
+      // 브랜드 플레이버의 옅게 씻어낸 청록 강조색 (dalewave 광택 / dalepulse 그라데이션의 청록 끝)
+      brandHighlight: {
+        value: { base: "{colors.teal.3}", _dark: "{colors.darkTeal.6}" },
+      },
+    },
   },
   border: {
     brand: {

--- a/src/tokens/gradients.mdx
+++ b/src/tokens/gradients.mdx
@@ -1,0 +1,64 @@
+import { colors } from "./colors";
+
+# Gradients
+
+달레 UI의 브랜드 그라데이션입니다. Panda CSS에는 그라데이션 토큰 카테고리가 없으므로,
+그라데이션은 `globalCss`의 `:root`에 정의된 테마 가능한 CSS 커스텀 속성으로 노출됩니다.
+어떤 컴포넌트에서든 `var(--gradient-brand)`로 재사용할 수 있습니다.
+
+## `--gradient-brand`
+
+청록에서 보라로 흐르는 풀컬러 달레 브랜드 그라데이션입니다. 브랜드 마크(`</>` 로고)와 동일한
+청록·보라 브랜드 색을 사용합니다(중간에 파랑이 자연스럽게 지나갑니다). 버튼·헤딩 등 어디서든
+재사용할 수 있는 시스템 토큰입니다.
+
+`Skeleton`의 브랜드 플레이버(`dalepulse`/`dalewave`)는 이 풀컬러 그라데이션을 그대로 쓰지 않고,
+같은 청록·보라 색을 **옅게 씻어낸 톤**(`bg.skeleton.brand` / `bg.skeleton.brandHighlight`, 테마 인지)으로
+사용합니다. 스켈레톤은 낮은 대비의 플레이스홀더여야 하기 때문입니다.
+
+<div
+  style={{
+    background: "var(--gradient-brand)",
+    width: "100%",
+    height: "120px",
+    borderRadius: "8px",
+  }}
+/>
+
+| 항목   | 값                                                            |
+| ------ | ------------------------------------------------------------- |
+| 변수   | `--gradient-brand`                                            |
+| 정의   | `linear-gradient(135deg, {colors.teal.9}, {colors.violet.9})` |
+| 시작색 | `colors.teal.9` (`{colors.teal[9].value}`)                    |
+| 끝색   | `colors.violet.9` (`{colors.violet[9].value}`)                |
+| 각도   | `135deg`                                                      |
+
+### 사용법
+
+```css
+.my-element {
+  background: var(--gradient-brand);
+}
+```
+
+```tsx
+import { Skeleton } from "daleui";
+
+// 달레 브랜드(청록·보라) 플레이버는 animation 이름만으로 선택됩니다.
+<Skeleton variant="rounded" animation="dalepulse" width={280} height={48} />; // 그라데이션 일렁임
+<Skeleton variant="rounded" animation="dalewave" width={280} height={48} />; // 보라 바탕 위 청록 웨이브
+```
+
+### 테마 안정성
+
+브랜드 마크(`</>` 로고)는 하나의 정적 자산으로 라이트/다크에서 동일합니다. 이 그라데이션도 같은
+브랜드 폴인 청록 `teal.9`(`{colors.teal[9].value}`)와 보라 `violet.9`(`{colors.violet[9].value}`)를
+고정값으로 사용하므로 테마와 무관하게 동일하며 별도의 `_dark` 재정의가 필요하지 않습니다.
+(`teal.9`는 다크 모드 단계 `darkTeal.9`와 값이 같습니다.)
+
+### 모션 안내
+
+그라데이션 자체는 정적인 채움이며, 움직임은 `Skeleton`의 브랜드 플레이버가 부여합니다.
+`dalepulse`는 옅은 브랜드 그라데이션이 제자리에서 일렁이고, `dalewave`는 옅은 보라 바탕 위로
+옅은 청록 웨이브가 흐릅니다(둘 다 풀컬러 `--gradient-brand`가 아니라 씻어낸 톤을 씁니다).
+두 애니메이션 모두 `prefers-reduced-motion: reduce` 환경에서 자동으로 멈추고 정적 채움으로 남습니다.


### PR DESCRIPTION
## 개요

로딩 상태를 표시하는 `Skeleton` 플레이스홀더 컴포넌트를 추가합니다.
Material UI `Skeleton`과 기능적으로 동등하며, 그 이상으로 `loading` 토글,
`prefers-reduced-motion` 처리, 올바른 a11y 시맨틱과 **달레 전용 브랜드 그라데이션**을 더했습니다.

배경과 합의 사항은 관련 이슈 #(이슈 번호)를 참고해 주세요.

## 구현 내용

- **컴포넌트** (`Object.assign` 컴파운드, `Card` 패턴): `Skeleton` + `Skeleton.Text` + `Skeleton.Avatar`
- **variant**: `text` / `circular` / `rectangular`(직각, MUI 패리티) / `rounded`(`md` 반경)
- **animation**: `pulse` / `wave`(중성 회색), `dalepulse` / `dalewave`(달레 브랜드 청록·보라,
  브랜드 마크 `</>` 로고와 동일한 색을 옅게 씻어낸 톤, `animation` 이름만으로 선택), `false`(정적).
  `dalewave`는 옅은 보라 바탕 위로 옅은 청록 웨이브가 흐르고, `dalepulse`는 옅은 청록→보라
  그라데이션이 제자리에서 일렁입니다. 풀컬러가 아니라 회색 스켈레톤과 같은 낮은 대비라
  플레이스홀더답게 보입니다.
- **loading 모델**: `loading`(기본 `true`) 토글 + 자식 추론(자식 크기에 맞춰 레이아웃 예약,
  `loading={false}`이면 실제 자식 렌더링)
- React 19 `ref`-as-prop, Panda `cva` 레시피, 모든 public 컴포넌트·prop에 한국어 JSDoc

## 변경 파일

신규:
- `src/components/Skeleton/Skeleton.tsx` (루트 + `Text` + `Avatar` + `cva` 레시피)
- `src/components/Skeleton/Skeleton.stories.tsx`
- `src/components/Skeleton/Skeleton.test.tsx`
- `src/tokens/gradients.mdx` (`--gradient-brand` 문서)

수정:
- `src/index.ts` — `Skeleton` 및 prop 타입 export
- `src/tokens/colors.ts` — `bg.skeleton` (+ `.highlight`)와 옅은 브랜드 톤
  `bg.skeleton.brand` / `.brandHighlight`(테마 인지) 추가
- `src/styles/globalCss.ts` — `--gradient-brand` 추가
- `panda.config.ts` — `pulse` / `wave` / `dalepulse` 키프레임 추가 (`dalewave`는 `wave`
  translateX 키프레임을 재사용)

> 토큰·키프레임 변경이 포함되므로 `bun run prepare`(panda codegen)로 `styled-system/`을
> 재생성해야 레시피가 해석됩니다.

## 접근성 및 모션 (`prefers-reduced-motion`)

- 시각적 플레이스홀더에 `aria-hidden="true"`(장식 요소이므로 읽히지 않음).
- 래퍼에 `aria-busy={loading}`로 로딩 영역을 알림(불필요한 live-region 소음 없이).
- **모든 애니메이션(`dalewave`/`dalepulse` 포함)은 `prefers-reduced-motion` 미디어 쿼리 뒤에
  게이트**되어, 동작 줄이기 환경에서는 정적 채움으로 대체됩니다. 브랜드 플레이버는 옅은 정적
  그라데이션, 회색 애니메이션은 정적 회색으로 남습니다.

## Chromatic / UI 리뷰

- 디자인 변경이므로 **`ui` 라벨**을 적용해 Chromatic 실행 및 디자이너 UI Review를 진행합니다.
- 애니메이션이 포함된 스토리는 스냅샷이 결정적이도록 **모션을 일시정지**합니다
  (`parameters: { chromatic: { pauseAnimationAtEnd: true } }`). 인터랙션 데모(LoadingToggle)는
  스냅샷을 비활성화(`disableSnapshot`)했습니다.

## 브랜드 그라데이션의 분리 가능성

`dalewave`/`dalepulse`와 `--gradient-brand`는 코어와 **깔끔하게 분리**되도록 설계했습니다.
디자인 사인오프에서 그라데이션이 채택되지 않으면, 중성 회색 스켈레톤은 그대로 독립적으로 동작하며
그라데이션 부분만 제거하면 됩니다.

## 검증 (로컬, Bun)

모든 검사를 로컬에서 통과했습니다.

- `bun run format` (Prettier) — 통과
- `bun run lint` (ESLint) — 통과 (에러 0)
- `bunx tsc -b` (타입 체크) — 통과
- `bun run test` (Vitest) — 전체 통과 (Skeleton 23 테스트 포함)
- `bun run build` — 통과 (Panda CSS 추출 확인: 키프레임 3종(`pulse`/`wave`/`dalepulse`),
  `dalewave`의 옅은 청록 광택+옅은 보라 바탕, 옅은 브랜드 토큰 `bg.skeleton.brand`/`.brandHighlight`
  해석(`violet.4`/`teal.3` 등), `--gradient-brand`(청록→보라) 풀컬러 변수, `bg.skeleton` 토큰,
  `prefers-reduced-motion` 게이트(모든 애니메이션 포함) 모두 정상, 미해석 `token()` 0건)

## 체크리스트

- [x] 관련 이슈를 Development 사이드바로 연결
- [ ] `ui` 라벨 적용
- [ ] 디자이너 UI Review (Chromatic 스냅샷)
- [ ] 메인테이너 승인 (최소 1, 권장 2)
