### PR TITLE
CheckboxGroup 컴포넌트 Ark UI 구조로 개선

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -17,6 +17,8 @@ export interface CheckboxProps extends Omit<FieldProps, "label"> {
   label?: string;
   /** 폼 name */
   name?: string;
+  /** 폼 제출 값. CheckboxGroup 내부에서 항목을 식별하는 데 사용됩니다. */
+  value?: string;
   /** 제어 모드 체크 여부 */
   checked?: boolean;
   /** 비제어 모드 초기 체크 여부 */
@@ -37,6 +39,7 @@ export const Checkbox = ({
   ref,
   label,
   name,
+  value,
   checked,
   defaultChecked,
   disabled,
@@ -72,6 +75,7 @@ export const Checkbox = ({
     <div>
       <ArkCheckbox.Root
         name={name}
+        value={value}
         checked={checked}
         defaultChecked={defaultChecked}
         disabled={isDisabled}

--- a/src/components/CheckboxGroup/CheckboxGroup.test.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.test.tsx
@@ -292,6 +292,16 @@ describe("CheckboxGroup", () => {
     expect(requiredText).toBeInTheDocument();
   });
 
+  test("그룹을 role=group으로 노출하고 label을 접근 가능한 이름으로 연결한다", () => {
+    render(
+      <CheckboxGroup name="test" label="좋아하는 과일">
+        <CheckboxGroup.Item value="apple">사과</CheckboxGroup.Item>
+      </CheckboxGroup>,
+    );
+    const group = screen.getByRole("group", { name: "좋아하는 과일" });
+    expect(group).toBeInTheDocument();
+  });
+
   test("helperText가 있으면 하단에 표시하고 aria-describedby로 연결한다", () => {
     render(
       <CheckboxGroup name="test" label="Test Group" helperText="도움말입니다.">
@@ -300,11 +310,8 @@ describe("CheckboxGroup", () => {
     );
     const help = screen.getByText("도움말입니다.");
     expect(help).toBeInTheDocument();
-    /** TODO: CheckboxGroup ArkUI 컴포넌트 구조 변경 후 수정 필요 */
-    // eslint-disable-next-line testing-library/no-node-access
-    const root = help.parentElement;
-    expect(root).not.toBeNull();
-    expect(root).toHaveAccessibleDescription("도움말입니다.");
+    const group = screen.getByRole("group");
+    expect(group).toHaveAccessibleDescription("도움말입니다.");
   });
 
   test("helperText가 있으면 invalid 여부와 관계없이 노출한다", () => {

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -1,9 +1,13 @@
 import {
+  CheckboxGroup as ArkCheckboxGroup,
+  useCheckboxGroupContext,
+} from "@ark-ui/react/checkbox";
+import {
   type ReactNode,
   type Ref,
   createContext,
   useContext,
-  useState,
+  useId,
 } from "react";
 import { css, cva } from "../../../styled-system/css";
 import { HelperText } from "../shared/HelperText";
@@ -14,13 +18,14 @@ import { Checkbox } from "../Checkbox/Checkbox";
 
 type CheckboxGroupTone = Extract<Tone, "brand" | "neutral">;
 
+/**
+ * 항목 스타일링에만 필요한 값(tone, invalid)을 전달하는 컨텍스트입니다.
+ * 선택 상태·disabled·readOnly·name은 ArkUI CheckboxGroup 컨텍스트가 관리합니다.
+ */
 const CheckboxGroupContext = createContext<
   | ({
       tone: CheckboxGroupTone;
-      name: string;
-      selectedValues: string[];
-      onValueChange: (value: string, checked: boolean) => void;
-    } & Pick<FieldProps, "disabled" | "invalid" | "readOnly">)
+    } & Pick<FieldProps, "invalid">)
   | null
 >(null);
 
@@ -92,6 +97,7 @@ function CheckboxGroupRoot({
   helperText,
   errorMessage,
 }: CheckboxGroupProps) {
+  const labelId = useId();
   const {
     fieldProps,
     helpTextProps,
@@ -100,43 +106,24 @@ function CheckboxGroupRoot({
     isReadOnly,
     isDisabled,
   } = useField({ helperText, errorMessage, invalid, disabled, readOnly });
-  const isControlled = values !== undefined;
-  const [internalValues, setInternalValues] = useState<string[]>(
-    defaultValues ?? [],
-  );
-
-  const selectedValues = isControlled ? values : internalValues;
-
-  const handleValueChange = (itemValue: string, checked: boolean) => {
-    const newValues = checked
-      ? [...selectedValues, itemValue]
-      : selectedValues.filter((v) => v !== itemValue);
-
-    if (!isControlled) {
-      setInternalValues(newValues);
-    }
-
-    onChange?.(newValues);
-  };
 
   return (
-    <CheckboxGroupContext.Provider
-      value={{
-        tone,
-        disabled: isDisabled,
-        invalid,
-        readOnly: isReadOnly,
-        name,
-        selectedValues,
-        onValueChange: handleValueChange,
-      }}
-    >
-      <div
+    <CheckboxGroupContext.Provider value={{ tone, invalid }}>
+      <ArkCheckboxGroup
         ref={ref}
-        className={checkboxGroupRootStyles}
+        name={name}
+        value={values}
+        defaultValue={defaultValues}
+        onValueChange={(value) => onChange?.(value)}
+        disabled={isDisabled}
+        readOnly={isReadOnly}
+        invalid={invalid}
+        aria-labelledby={labelId}
         aria-describedby={fieldProps["aria-describedby"]}
+        className={checkboxGroupRootStyles}
       >
-        <label
+        <span
+          id={labelId}
           className={css({
             textStyle: "label.md.strong",
             marginBottom: "8",
@@ -172,14 +159,14 @@ function CheckboxGroupRoot({
               </span>
             </>
           )}
-        </label>
+        </span>
         <div className={checkboxGroupStyles({ orientation })}>{children}</div>
         {showBottomText && (
           <HelperText {...helpTextProps} disabled={isDisabled}>
             {bottomText}
           </HelperText>
         )}
-      </div>
+      </ArkCheckboxGroup>
     </CheckboxGroupContext.Provider>
   );
 }
@@ -226,6 +213,7 @@ export function CheckboxGroupItem({
   disabled = false,
 }: CheckboxGroupItemProps) {
   const context = useContext(CheckboxGroupContext);
+  const group = useCheckboxGroupContext();
 
   if (!context) {
     throw new Error(
@@ -233,33 +221,18 @@ export function CheckboxGroupItem({
     );
   }
 
-  const {
-    tone,
-    disabled: groupDisabled,
-    invalid: groupInvalid,
-    readOnly: groupReadOnly,
-    name,
-    selectedValues,
-    onValueChange,
-  } = context;
-  const isDisabled = disabled || groupDisabled;
-  const isInvalid = groupInvalid;
-  const isChecked = selectedValues.includes(value);
-
-  const handleChange = (checked: boolean) => {
-    onValueChange(value, checked);
-  };
+  const { tone, invalid } = context;
+  const isDisabled = disabled || (group?.disabled ?? false);
+  const isReadOnly = group?.readOnly ?? false;
 
   return (
     <Checkbox
       label={children}
-      name={name}
-      checked={isChecked}
+      value={value}
       disabled={isDisabled}
-      readOnly={groupReadOnly}
-      invalid={!isDisabled && isInvalid}
+      readOnly={isReadOnly}
+      invalid={!isDisabled && !!invalid}
       tone={tone}
-      onChange={handleChange}
     />
   );
 }

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -1,7 +1,4 @@
-import {
-  CheckboxGroup as ArkCheckboxGroup,
-  useCheckboxGroupContext,
-} from "@ark-ui/react/checkbox";
+import { CheckboxGroup as ArkCheckboxGroup } from "@ark-ui/react/checkbox";
 import {
   type ReactNode,
   type Ref,
@@ -19,13 +16,13 @@ import { Checkbox } from "../Checkbox/Checkbox";
 type CheckboxGroupTone = Extract<Tone, "brand" | "neutral">;
 
 /**
- * 항목 스타일링에만 필요한 값(tone, invalid)을 전달하는 컨텍스트입니다.
- * 선택 상태·disabled·readOnly·name은 ArkUI CheckboxGroup 컨텍스트가 관리합니다.
+ * 항목 스타일링에 필요한 값을 전달하는 컨텍스트입니다.
+ * 선택 상태와 name은 ArkUI CheckboxGroup 컨텍스트가 관리합니다.
  */
 const CheckboxGroupContext = createContext<
   | ({
       tone: CheckboxGroupTone;
-    } & Pick<FieldProps, "invalid">)
+    } & Pick<FieldProps, "invalid" | "disabled" | "readOnly">)
   | null
 >(null);
 
@@ -108,7 +105,9 @@ function CheckboxGroupRoot({
   } = useField({ helperText, errorMessage, invalid, disabled, readOnly });
 
   return (
-    <CheckboxGroupContext.Provider value={{ tone, invalid }}>
+    <CheckboxGroupContext.Provider
+      value={{ tone, invalid, disabled: isDisabled, readOnly: isReadOnly }}
+    >
       <ArkCheckboxGroup
         ref={ref}
         name={name}
@@ -213,7 +212,6 @@ export function CheckboxGroupItem({
   disabled = false,
 }: CheckboxGroupItemProps) {
   const context = useContext(CheckboxGroupContext);
-  const group = useCheckboxGroupContext();
 
   if (!context) {
     throw new Error(
@@ -221,17 +219,16 @@ export function CheckboxGroupItem({
     );
   }
 
-  const { tone, invalid } = context;
-  const isDisabled = disabled || (group?.disabled ?? false);
-  const isReadOnly = group?.readOnly ?? false;
+  const { tone, invalid, disabled: groupDisabled, readOnly } = context;
+  const isDisabled = disabled || groupDisabled;
 
   return (
     <Checkbox
       label={children}
       value={value}
       disabled={isDisabled}
-      readOnly={isReadOnly}
-      invalid={!isDisabled && !!invalid}
+      readOnly={readOnly}
+      invalid={!isDisabled && invalid}
       tone={tone}
     />
   );


### PR DESCRIPTION
Closes #977

`CheckboxGroup`을 `RadioGroup`과 동일하게 Ark UI의 `CheckboxGroup` 구조로 개선했습니다.

기존에는 수제 React Context + `useState`로 선택 상태를 관리하고 그룹 컨테이너가 `role` 없는 `div`라서 `aria-describedby` 등 그룹 수준 접근성을 테스트하기 어려웠습니다.

- 루트를 `ArkCheckboxGroup`으로 교체해 선택 값·`name`·`disabled`·`readOnly`·`invalid`를 Ark UI가 관리합니다.
- 루트가 `role="group"`을 렌더링하므로 `aria-labelledby`(레이블)·`aria-describedby`(보조/에러 메시지)를 연결했습니다.
- `CheckboxGroup.Item`은 기존 `Checkbox` 컴포넌트를 재사용하며, 그룹 통합을 위해 `Checkbox`에 `value` prop을 추가했습니다.

## 테스팅

- 부모 노드를 직접 탐색하던 임시 코드(`TODO`)를 `getByRole("group")` + `toHaveAccessibleDescription`으로 교체하고, `role="group"`·접근 가능한 이름 검증 테스트를 추가했습니다.
- 기존 동작 테스트가 모두 통과함을 확인했습니다.

## 체크 리스트

- [x] 코드 리뷰를 요청하기 전에 반드시 CI가 통과하는지 확인해주세요.
- [ ] 컴포넌트나 스토리 변경이 있는 경우 PR에 ui 태그를 달아주세요.
  - [ ] UI Tests를 통해 스냅샷 차이가 의도된 것인지 확인해주세요.
  - [ ] UI Review를 통해 디자이너에게 리뷰를 요청하고 승인을 받으세요.
