### PR TITLE
DISCORD_SERVER_ID -> DISCORD_GUILD_ID

### DIFF
--- a/.github/workflows/create-meeting-issue.yml
+++ b/.github/workflows/create-meeting-issue.yml
@@ -82,7 +82,7 @@ jobs:
         id: create-event # 다음 스텝에서 event_id 참조하기 위해 id 부여
         env:
           DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
-          DISCORD_SERVER_ID: ${{ vars.DISCORD_SERVER_ID }}
+          DISCORD_GUILD_ID: ${{ vars.DISCORD_GUILD_ID }}
           TITLE: ${{ steps.meeting-info.outputs.title }}
           ISSUE_URL: ${{ steps.create-issue.outputs.issue_url }}
         run: |
@@ -99,7 +99,7 @@ jobs:
           START_UNIX=$(date -d "${NEXT_SAT}T00:30:00+00:00" +%s)
 
           RESPONSE=$(curl -sf --show-error -X POST \
-            "https://discord.com/api/v10/guilds/${DISCORD_SERVER_ID}/scheduled-events" \
+            "https://discord.com/api/v10/guilds/${DISCORD_GUILD_ID}/scheduled-events" \
             -H "Authorization: Bot ${DISCORD_TOKEN}" \
             -H "Content-Type: application/json" \
             -d "{
@@ -122,7 +122,7 @@ jobs:
         if: steps.meeting-info.outputs.type != 'skip'
         env:
           DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
-          DISCORD_SERVER_ID: ${{ vars.DISCORD_SERVER_ID }}
+          DISCORD_GUILD_ID: ${{ vars.DISCORD_GUILD_ID }}
           DISCORD_DALEUI_CHAT_CHANNEL_ID: ${{ vars.DISCORD_DALEUI_CHAT_CHANNEL_ID }}
           DISCORD_DALEUI_ROLE_ID: ${{ vars.DISCORD_DALEUI_ROLE_ID }}
           TITLE: ${{ steps.meeting-info.outputs.title }}
@@ -130,7 +130,7 @@ jobs:
           EVENT_ID: ${{ steps.create-event.outputs.event_id }}
           START_UNIX: ${{ steps.create-event.outputs.start_unix }}
         run: |
-          EVENT_LINK="https://discord.com/events/${DISCORD_SERVER_ID}/${EVENT_ID}"
+          EVENT_LINK="https://discord.com/events/${DISCORD_GUILD_ID}/${EVENT_ID}"
 
           # 디자인시스템-채팅 채널에 회의 일정 공지 및 RSVP 유도 메시지 전송
           curl -sf --show-error -X POST \


### PR DESCRIPTION
<!-- PR에 대해 알아야 하는 내용은 위키의 컨벤션을 확인해 주세요.
위키 - https://github.com/DaleStudy/daleui/wiki/Conventions -->

PR #1162 에서 이벤트 자동화 워크플로우가 생성되었는데요. 참조하고 있는 `DISCORD_SERVER_ID`가 현재 저장소 수준에 저장되어 있습니다. 운영진 합의 내용에 따라서 조직 수준에서 관리되고 있는 `DISCORD_GUILD_ID`를 사용하도록 변경합니다.

혼선이 없도록 PR이 병합된 후에 저장소에서 DISCORD_SERVER_ID를 삭제해야합니다.

## 테스팅

<!-- 변경 사항이 의도대로 동작하는지 어떻게 확인했나요? (예: 스크린샷 또는 비디오 첨부, 테스트 단계 설명) -->

단순 환경 변수 이름 교체 건이라서 기존에 잘 작동했었다면 문제가 없을 것입니다.

## 체크 리스트

- [x] 코드 리뷰를 요청하기 전에 반드시 CI가 통과하는지 확인해주세요.
- [x] 컴포넌트나 스토리 변경이 있는 경우 PR에 ui 태그를 달아주세요.
  - [ ] UI Tests를 통해 스냅샷 차이가 의도된 것인지 확인해주세요.
  - [ ] UI Review를 통해 디자이너에게 리뷰를 요청하고 승인을 받으세요.

<!-- UI Review 및 UI Tests에 대한 내용은 상단 컨벤션 문서의 '7. PR리뷰 및 병합' 내용을 참고해 주세요. -->
