### PR TITLE
ci: UI 관련 파일 변경 시 PR에 `ui` 라벨 자동 부여

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,11 @@
+# 화면에 영향을 주는 파일이 바뀌면 ui 라벨을 자동으로 단다.
+ui:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/components/**"
+          - "src/examples/**"
+          - "**/*.stories.@(ts|tsx|js|jsx|mdx)"
+          - ".storybook/**"
+          - "src/tokens/**"
+          - "src/styles/**"
+          - "panda.config.ts"

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,6 +1,7 @@
 name: "Chromatic 🎨"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -36,11 +37,12 @@ jobs:
 
   pre-chromatic:
     needs: changes
-    # ui 라벨이 있거나 UI 경로가 바뀌면 실행, main push는 항상.
-    # push일 땐 changes가 skip이라 !cancelled()로 풀어준다.
+    # ui 라벨이 있거나 UI 경로가 바뀌면 실행, main push·수동 실행은 항상.
+    # push/workflow_dispatch일 땐 changes가 skip이라 !cancelled()로 풀어준다.
     if: >-
       !cancelled() &&
       (github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'ui') ||
       needs.changes.outputs.ui == 'true')
     runs-on: ubuntu-latest

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,11 +5,44 @@ on:
     branches:
       - main
   pull_request:
-    types: [labeled, synchronize]
+    types: [labeled, opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
+  # UI 관련 파일이 바뀌었는지 확인. 라벨과 OR로 묶으려고 native paths 대신 여기서 판별한다.
+  # (경로는 .github/labeler.yml과 맞춰둘 것)
+  changes:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      ui: ${{ steps.filter.outputs.ui }}
+    steps:
+      # 바뀐 파일이 아래 필터에 걸리는지 검사해 ui 출력값(true/false)을 내보낸다
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            ui:
+              - "src/components/**"
+              - "src/examples/**"
+              - "**/*.stories.@(ts|tsx|js|jsx|mdx)"
+              - ".storybook/**"
+              - "src/tokens/**"
+              - "src/styles/**"
+              - "panda.config.ts"
+
   pre-chromatic:
-    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ui')
+    needs: changes
+    # ui 라벨이 있거나 UI 경로가 바뀌면 실행, main push는 항상.
+    # push일 땐 changes가 skip이라 !cancelled()로 풀어준다.
+    if: >-
+      !cancelled() &&
+      (github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'ui') ||
+      needs.changes.outputs.ui == 'true')
     runs-on: ubuntu-latest
     steps:
       - id: gen_url
@@ -21,12 +54,12 @@ jobs:
       url: ${{ steps.gen_url.outputs.url }}
 
   chromatic:
-    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ui')
+    needs: pre-chromatic
+    if: needs.pre-chromatic.result == 'success'
     environment:
       name: chromatic
       url: ${{ needs.pre-chromatic.outputs.url }}
     runs-on: ubuntu-latest
-    needs: pre-chromatic
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+name: Labeler 🏷️
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          # 수동으로 단 다른 라벨은 건드리지 않는다.
+          sync-labels: false


### PR DESCRIPTION
Closes #1157

Chromatic 워크플로우(`chromatic.yml`)는 PR에 `ui` 라벨이 있어야 실행되는데, 이 라벨을 수동으로 달다 보니 누락되면 UI 변경이 있어도 visual regression 테스트가 돌지 않았습니다. `actions/labeler`로 화면에 영향을 주는 파일이 바뀌면 `ui` 라벨이 자동으로 붙도록 했습니다.

- `.github/labeler.yml`에 `ui` 라벨을 달 경로를 정의했습니다. 컴포넌트·스토리·예제(`src/components/**`, `src/examples/**`, `**/*.stories.tsx`), Storybook 설정(`.storybook/**`), 그리고 렌더링 결과에 영향을 주는 토큰·스타일·Panda 설정(`src/tokens/**`, `src/styles/**`, `panda.config.ts`)을 대상으로 했습니다.
- `.github/workflows/labeler.yml`은 `pull_request_target`(opened/reopened/synchronize)에서 실행됩니다. fork PR에서도 라벨이 달리도록 `pull_request_target`을 쓰고, 권한은 `pull-requests: write`로 한정했습니다. PR 코드를 checkout·실행하지 않고 변경 파일 목록만 API로 읽으므로 `pull_request_target`이지만 안전합니다. `sync-labels: false`라 수동으로 단 다른 라벨은 건드리지 않습니다.
- `ui` 라벨은 이미 레포에 있어 따로 만들 필요는 없습니다.

한 가지 짚어둘 점이 있습니다. 기본 `GITHUB_TOKEN`으로 단 라벨은 다른 워크플로우를 재트리거하지 않아서(재귀 방지), 라벨러가 `ui`를 달아도 chromatic의 `labeled` 이벤트는 발생하지 않습니다. 게다가 chromatic은 `[labeled, synchronize]`에서만 돌고 `opened`는 트리거가 아니라서, PR을 열자마자는 chromatic이 돌지 않고 이후 커밋이 push되는 `synchronize` 시점부터 실행됩니다. 지금까지 사람이 라벨을 직접 달면 `labeled`가 떠서 즉시 돌던 것과 달리, 자동 라벨은 그 즉시성을 갖지 못하고, 단일 커밋으로 열고 이후 push가 없는 PR은 자동 실행이 안 될 수 있습니다.

즉시성까지 확보하려면 후속으로 (1) 라벨 대신 chromatic을 `paths` 기준으로 트리거해 라벨 의존을 없애거나, (2) 라벨러가 PAT/GitHub App 토큰으로 라벨을 달아 `labeled`가 정상 발생하게 하는 방법이 있습니다. 이 PR은 우선 자동 라벨 부여까지만 다룹니다.

## 테스팅

- 워크플로우 설정 추가라 로컬 확인은 어렵고, 머지 후 UI 파일을 건드리는 PR에서 `ui` 라벨이 자동으로 붙는지로 확인할 수 있습니다.

## 체크 리스트

- [x] 코드 리뷰를 요청하기 전에 반드시 CI가 통과하는지 확인해주세요.
- [ ] 컴포넌트나 스토리 변경이 있는 경우 PR에 ui 태그를 달아주세요.
  - [ ] UI Tests를 통해 스냅샷 차이가 의도된 것인지 확인해주세요.
  - [ ] UI Review를 통해 디자이너에게 리뷰를 요청하고 승인을 받으세요.