### PR TITLE
ci: Chromatic 워크플로우 수동 실행(workflow_dispatch) 지원

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,6 +1,7 @@
 name: "Chromatic 🎨"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -9,7 +10,7 @@ on:
 
 jobs:
   pre-chromatic:
-    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ui')
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ui')
     runs-on: ubuntu-latest
     steps:
       - id: gen_url
@@ -21,7 +22,7 @@ jobs:
       url: ${{ steps.gen_url.outputs.url }}
 
   chromatic:
-    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ui')
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ui')
     environment:
       name: chromatic
       url: ${{ needs.pre-chromatic.outputs.url }}


### PR DESCRIPTION
## 개요

Chromatic 워크플로우를 Actions 탭에서 수동으로 실행할 수 있게 `workflow_dispatch` 트리거를 추가했습니다. #1179 리뷰에서 나온 수동 실행 가능 여부 논의에 대한 대응입니다.

## 변경 내용

- `on:`에 `workflow_dispatch`를 추가해 Actions 탭에 수동 실행 버튼이 뜨도록 했습니다.
- `pre-chromatic`·`chromatic` 두 잡의 `if` 조건에 `github.event_name == 'workflow_dispatch'`를 추가했습니다. 기존 조건은 `push`이거나 PR에 `ui` 라벨이 있을 때만 잡을 실행하므로, 이 보정이 없으면 수동 실행해도 두 잡이 모두 스킵됩니다.
- 체크아웃 ref·`CHROMATIC_BRANCH`·`CHROMATIC_SHA`는 이미 `... || github.ref_name`, `... || github.sha` 폴백이 있어 수동 실행(선택한 브랜치 기준)에서도 그대로 동작합니다. 추가 수정은 없습니다.

## 테스팅

- 워크플로우 설정 변경이라 로컬 검증은 어렵습니다. 머지 후 Actions 탭 > Chromatic 🎨 > Run workflow로 원하는 브랜치를 선택해 수동 실행되는지 확인할 수 있습니다.