### PR TITLE
기본 프리셋에서 유입된 serif 폰트 토큰 제거

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -17,7 +17,10 @@ import {
 export default defineConfig({
   // 기본 프리셋의 serif 토큰은 상용 시스템 폰트(Cambria 등)를 참조하므로
   // fonts 카테고리를 달레UI가 지원하는 폰트(sans, mono)로 대체한다
+  // presets를 명시하면 기본값이 통째로 대체되므로 utilities를 제공하는
+  // @pandacss/preset-base를 반드시 함께 나열해야 한다
   presets: [
+    "@pandacss/preset-base",
     {
       ...pandaPreset,
       theme: {

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "@pandacss/dev";
+import pandaPreset from "@pandacss/dev/presets";
 import { globalCss } from "./src/styles/globalCss";
 import { borderWidths, borders } from "./src/tokens/borders";
 import { colors, semanticColors } from "./src/tokens/colors";
@@ -14,6 +15,18 @@ import {
 } from "./src/tokens/typography";
 
 export default defineConfig({
+  // 기본 프리셋의 serif 토큰은 상용 시스템 폰트(Cambria 등)를 참조하므로
+  // fonts 카테고리를 달레UI가 지원하는 폰트(sans, mono)로 대체한다
+  presets: [
+    {
+      ...pandaPreset,
+      theme: {
+        ...pandaPreset.theme,
+        tokens: { ...pandaPreset.theme.tokens, fonts },
+      },
+    },
+  ],
+
   // Whether to use css reset
   preflight: true,
 
@@ -62,7 +75,6 @@ export default defineConfig({
         borders,
         borderWidths,
         colors,
-        fonts,
         fontWeights,
         fontSizes,
         letterSpacings,


### PR DESCRIPTION
기본 프리셋(preset-panda)에서 유입되던 serif 폰트 토큰(`--fonts-serif`)이 상용 시스템 폰트(Cambria 등)를 참조하고 있어, 프리셋의 fonts 카테고리를 달레UI가 실제 지원하는 폰트(sans, mono)로 대체해 제거했습니다. 이 토큰은 컴포넌트 사용처가 0곳인데도 번들 CSS에 공개 API처럼 노출되고 있었고, 업스트림(chakra-ui/panda)은 최신 버전과 v2 베타 모두 이 토큰을 유지하고 있어 프로젝트 쪽에서 조치했습니다.