### PR TITLE
Divider 구현

### DIFF
--- a/src/components/Divider/Divider.stories.tsx
+++ b/src/components/Divider/Divider.stories.tsx
@@ -1,0 +1,179 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { css } from "../../../styled-system/css";
+import { hstack, vstack } from "../../../styled-system/patterns";
+import { Text } from "../Text/Text";
+import { Divider } from "./Divider";
+
+export default {
+  component: Divider,
+  parameters: {
+    layout: "centered",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/mQ2ETYC6LXGOwVETov3CgO/DaleUI-Kit?node-id=9346-128&t=U9pxZQB7bzamQwER-1",
+    },
+  },
+  args: {
+    orientation: "horizontal",
+    variant: "solid",
+    stroke: "sm",
+  },
+} satisfies Meta<typeof Divider>;
+
+export const Basic: StoryObj<typeof Divider> = {
+  render: (args) => (
+    <div
+      className={css({
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: "240px",
+        height: "80px",
+      })}
+    >
+      <Divider {...args} />
+    </div>
+  ),
+};
+
+export const Orientations: StoryObj<typeof Divider> = {
+  render: () => (
+    <div className={vstack({ gap: "24", alignItems: "flex-start" })}>
+      <div className={vstack({ gap: "8", alignItems: "flex-start" })}>
+        <Text size="sm" muted>
+          horizontal (기본값)
+        </Text>
+        <div className={css({ width: "240px" })}>
+          <Divider orientation="horizontal" />
+        </div>
+      </div>
+      <div className={vstack({ gap: "8", alignItems: "flex-start" })}>
+        <Text size="sm" muted>
+          vertical
+        </Text>
+        <div className={hstack({ gap: "8", height: "80px" })}>
+          <span>왼쪽</span>
+          <Divider orientation="vertical" />
+          <span>오른쪽</span>
+        </div>
+      </div>
+    </div>
+  ),
+  argTypes: {
+    orientation: { control: false },
+  },
+};
+
+export const Variants: StoryObj<typeof Divider> = {
+  render: () => (
+    <div
+      className={vstack({
+        gap: "24",
+        alignItems: "flex-start",
+        width: "240px",
+      })}
+    >
+      <div
+        className={vstack({
+          gap: "8",
+          alignItems: "flex-start",
+          width: "100%",
+        })}
+      >
+        <Text size="sm" muted>
+          solid (기본값)
+        </Text>
+        <Divider variant="solid" />
+      </div>
+      <div
+        className={vstack({
+          gap: "8",
+          alignItems: "flex-start",
+          width: "100%",
+        })}
+      >
+        <Text size="sm" muted>
+          dashed
+        </Text>
+        <Divider variant="dashed" />
+      </div>
+    </div>
+  ),
+  argTypes: {
+    variant: { control: false },
+  },
+};
+
+export const Strokes: StoryObj<typeof Divider> = {
+  render: () => (
+    <div
+      className={vstack({
+        gap: "24",
+        alignItems: "flex-start",
+        width: "240px",
+      })}
+    >
+      <div
+        className={vstack({
+          gap: "8",
+          alignItems: "flex-start",
+          width: "100%",
+        })}
+      >
+        <Text size="sm" muted>
+          sm · 1px (기본값)
+        </Text>
+        <Divider stroke="sm" />
+      </div>
+      <div
+        className={vstack({
+          gap: "8",
+          alignItems: "flex-start",
+          width: "100%",
+        })}
+      >
+        <Text size="sm" muted>
+          xs · 0.5px
+        </Text>
+        <Divider stroke="xs" />
+      </div>
+    </div>
+  ),
+  argTypes: {
+    stroke: { control: false },
+  },
+};
+
+export const ListUsage: StoryObj<typeof Divider> = {
+  render: () => (
+    <div className={vstack({ gap: "24", alignItems: "flex-start" })}>
+      <div
+        className={vstack({
+          gap: "8",
+          alignItems: "flex-start",
+          width: "160px",
+        })}
+      >
+        <span>리스트 아이템 1</span>
+        <span>리스트 아이템 2</span>
+        <span>리스트 아이템 3</span>
+        <Divider />
+        <span>리스트 아이템 A</span>
+        <span>리스트 아이템 B</span>
+      </div>
+      <div className={hstack({ gap: "8", alignItems: "stretch" })}>
+        <span>리스트 아이템 1</span>
+        <span>리스트 아이템 2</span>
+        <span>리스트 아이템 3</span>
+        <Divider orientation="vertical" />
+        <span>리스트 아이템 A</span>
+        <span>리스트 아이템 B</span>
+      </div>
+    </div>
+  ),
+  argTypes: {
+    orientation: { control: false },
+    variant: { control: false },
+    stroke: { control: false },
+  },
+};

--- a/src/components/Divider/Divider.stories.tsx
+++ b/src/components/Divider/Divider.stories.tsx
@@ -37,14 +37,14 @@ export const Basic: StoryObj<typeof Divider> = {
 };
 
 export const Orientations: StoryObj<typeof Divider> = {
-  render: () => (
+  render: (args) => (
     <div className={vstack({ gap: "24", alignItems: "flex-start" })}>
       <div className={vstack({ gap: "8", alignItems: "flex-start" })}>
         <Text size="sm" muted>
           horizontal (기본값)
         </Text>
         <div className={css({ width: "240px" })}>
-          <Divider orientation="horizontal" />
+          <Divider {...args} orientation="horizontal" />
         </div>
       </div>
       <div className={vstack({ gap: "8", alignItems: "flex-start" })}>
@@ -53,7 +53,7 @@ export const Orientations: StoryObj<typeof Divider> = {
         </Text>
         <div className={hstack({ gap: "8", height: "80px" })}>
           <span>왼쪽</span>
-          <Divider orientation="vertical" />
+          <Divider {...args} orientation="vertical" />
           <span>오른쪽</span>
         </div>
       </div>
@@ -65,7 +65,7 @@ export const Orientations: StoryObj<typeof Divider> = {
 };
 
 export const Variants: StoryObj<typeof Divider> = {
-  render: () => (
+  render: (args) => (
     <div
       className={vstack({
         gap: "24",
@@ -83,7 +83,7 @@ export const Variants: StoryObj<typeof Divider> = {
         <Text size="sm" muted>
           solid (기본값)
         </Text>
-        <Divider variant="solid" />
+        <Divider {...args} variant="solid" />
       </div>
       <div
         className={vstack({
@@ -95,7 +95,7 @@ export const Variants: StoryObj<typeof Divider> = {
         <Text size="sm" muted>
           dashed
         </Text>
-        <Divider variant="dashed" />
+        <Divider {...args} variant="dashed" />
       </div>
     </div>
   ),
@@ -105,7 +105,7 @@ export const Variants: StoryObj<typeof Divider> = {
 };
 
 export const Strokes: StoryObj<typeof Divider> = {
-  render: () => (
+  render: (args) => (
     <div
       className={vstack({
         gap: "24",
@@ -123,7 +123,7 @@ export const Strokes: StoryObj<typeof Divider> = {
         <Text size="sm" muted>
           sm · 1px (기본값)
         </Text>
-        <Divider stroke="sm" />
+        <Divider {...args} stroke="sm" />
       </div>
       <div
         className={vstack({
@@ -135,7 +135,7 @@ export const Strokes: StoryObj<typeof Divider> = {
         <Text size="sm" muted>
           xs · 0.5px
         </Text>
-        <Divider stroke="xs" />
+        <Divider {...args} stroke="xs" />
       </div>
     </div>
   ),
@@ -145,7 +145,7 @@ export const Strokes: StoryObj<typeof Divider> = {
 };
 
 export const ListUsage: StoryObj<typeof Divider> = {
-  render: () => (
+  render: (args) => (
     <div className={vstack({ gap: "24", alignItems: "flex-start" })}>
       <div
         className={vstack({
@@ -157,7 +157,7 @@ export const ListUsage: StoryObj<typeof Divider> = {
         <span>리스트 아이템 1</span>
         <span>리스트 아이템 2</span>
         <span>리스트 아이템 3</span>
-        <Divider />
+        <Divider {...args} orientation="horizontal" />
         <span>리스트 아이템 A</span>
         <span>리스트 아이템 B</span>
       </div>
@@ -165,7 +165,7 @@ export const ListUsage: StoryObj<typeof Divider> = {
         <span>리스트 아이템 1</span>
         <span>리스트 아이템 2</span>
         <span>리스트 아이템 3</span>
-        <Divider orientation="vertical" />
+        <Divider {...args} orientation="vertical" />
         <span>리스트 아이템 A</span>
         <span>리스트 아이템 B</span>
       </div>
@@ -173,7 +173,5 @@ export const ListUsage: StoryObj<typeof Divider> = {
   ),
   argTypes: {
     orientation: { control: false },
-    variant: { control: false },
-    stroke: { control: false },
   },
 };

--- a/src/components/Divider/Divider.test.tsx
+++ b/src/components/Divider/Divider.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { expect, test } from "vitest";
+import { Divider } from "./Divider";
+
+test("기본값으로 렌더링하면 hr 요소로 렌더링된다", () => {
+  render(<Divider data-testid="divider" />);
+  const divider = screen.getByTestId("divider");
+  expect(divider.tagName).toBe("HR");
+});
+
+test("orientation이 horizontal이면 hr 요소로 렌더링된다", () => {
+  render(<Divider orientation="horizontal" data-testid="divider" />);
+  const divider = screen.getByTestId("divider");
+  expect(divider.tagName).toBe("HR");
+});
+
+test("orientation이 vertical이면 separator 역할의 div로 렌더링된다", () => {
+  render(<Divider orientation="vertical" data-testid="divider" />);
+  const divider = screen.getByTestId("divider");
+  expect(divider.tagName).toBe("DIV");
+  expect(divider).toHaveAttribute("role", "separator");
+  expect(divider).toHaveAttribute("aria-orientation", "vertical");
+});
+
+test("variant를 올바르게 적용한다", () => {
+  render(<Divider variant="dashed" data-testid="divider" />);
+  const divider = screen.getByTestId("divider");
+  expect(divider.className).toMatch("border-top-style_dashed");
+});
+
+test("stroke를 올바르게 적용한다", () => {
+  render(
+    <div>
+      <Divider stroke="xs" data-testid="divider-xs" />
+      <Divider stroke="sm" data-testid="divider-sm" />
+    </div>,
+  );
+  expect(screen.getByTestId("divider-xs").className).toMatch("bd-t-w_xs");
+  expect(screen.getByTestId("divider-sm").className).toMatch("bd-t-w_sm");
+});
+
+test("className을 병합한다", () => {
+  render(<Divider className="custom-class" data-testid="divider" />);
+  expect(screen.getByTestId("divider")).toHaveClass("custom-class");
+});
+
+test("ref를 전달한다", () => {
+  let refValue: HTMLElement | null = null;
+  render(
+    <Divider
+      ref={(el) => {
+        refValue = el;
+      }}
+    />,
+  );
+  expect(refValue).not.toBeNull();
+});

--- a/src/components/Divider/Divider.test.tsx
+++ b/src/components/Divider/Divider.test.tsx
@@ -3,45 +3,44 @@ import { expect, test } from "vitest";
 import { Divider } from "./Divider";
 
 test("기본값으로 렌더링하면 hr 요소로 렌더링된다", () => {
-  render(<Divider data-testid="divider" />);
-  const divider = screen.getByTestId("divider");
-  expect(divider.tagName).toBe("HR");
+  render(<Divider />);
+  expect(screen.getByRole("separator").tagName).toBe("HR");
 });
 
 test("orientation이 horizontal이면 hr 요소로 렌더링된다", () => {
-  render(<Divider orientation="horizontal" data-testid="divider" />);
-  const divider = screen.getByTestId("divider");
-  expect(divider.tagName).toBe("HR");
+  render(<Divider orientation="horizontal" />);
+  expect(screen.getByRole("separator").tagName).toBe("HR");
 });
 
 test("orientation이 vertical이면 separator 역할의 div로 렌더링된다", () => {
-  render(<Divider orientation="vertical" data-testid="divider" />);
-  const divider = screen.getByTestId("divider");
+  render(<Divider orientation="vertical" />);
+  const divider = screen.getByRole("separator");
   expect(divider.tagName).toBe("DIV");
-  expect(divider).toHaveAttribute("role", "separator");
   expect(divider).toHaveAttribute("aria-orientation", "vertical");
 });
 
 test("variant를 올바르게 적용한다", () => {
-  render(<Divider variant="dashed" data-testid="divider" />);
-  const divider = screen.getByTestId("divider");
-  expect(divider.className).toMatch("border-top-style_dashed");
+  render(<Divider variant="dashed" />);
+  expect(screen.getByRole("separator").className).toMatch(
+    "border-top-style_dashed",
+  );
 });
 
 test("stroke를 올바르게 적용한다", () => {
   render(
     <div>
-      <Divider stroke="xs" data-testid="divider-xs" />
-      <Divider stroke="sm" data-testid="divider-sm" />
+      <Divider stroke="xs" />
+      <Divider stroke="sm" />
     </div>,
   );
-  expect(screen.getByTestId("divider-xs").className).toMatch("bd-t-w_xs");
-  expect(screen.getByTestId("divider-sm").className).toMatch("bd-t-w_sm");
+  const [xs, sm] = screen.getAllByRole("separator");
+  expect(xs.className).toMatch("bd-t-w_xs");
+  expect(sm.className).toMatch("bd-t-w_sm");
 });
 
 test("className을 병합한다", () => {
-  render(<Divider className="custom-class" data-testid="divider" />);
-  expect(screen.getByTestId("divider")).toHaveClass("custom-class");
+  render(<Divider className="custom-class" />);
+  expect(screen.getByRole("separator")).toHaveClass("custom-class");
 });
 
 test("ref를 전달한다", () => {

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -1,0 +1,111 @@
+import type { HTMLAttributes, Ref } from "react";
+import { cva, cx } from "../../../styled-system/css";
+
+export interface DividerProps extends HTMLAttributes<HTMLElement> {
+  /** 방향 */
+  orientation?: "horizontal" | "vertical";
+  /** 선 스타일 */
+  variant?: "solid" | "dashed";
+  /** 두께 */
+  stroke?: "xs" | "sm";
+  /** 요소 참조 */
+  ref?: Ref<HTMLElement>;
+}
+
+/**
+ * Divider는 콘텐츠를 시각적으로 구분하는 선입니다.
+ *
+ * - `orientation="horizontal"`(기본값)은 세로로 쌓인 콘텐츠를 가로 선으로 구분할 때, `orientation="vertical"`은 가로로 나열된 콘텐츠를 세로 선으로 구분할 때 사용합니다.
+ */
+export function Divider({
+  ref,
+  orientation = "horizontal",
+  variant = "solid",
+  stroke = "sm",
+  className,
+  ...rest
+}: DividerProps) {
+  const lineStyle = styles({ orientation, variant, stroke });
+
+  if (orientation === "vertical") {
+    return (
+      <div
+        ref={ref as Ref<HTMLDivElement>}
+        role="separator"
+        aria-orientation="vertical"
+        className={cx(lineStyle, className)}
+        {...(rest as HTMLAttributes<HTMLDivElement>)}
+      />
+    );
+  }
+
+  return (
+    <hr
+      ref={ref as Ref<HTMLHRElement>}
+      className={cx(lineStyle, className)}
+      {...(rest as HTMLAttributes<HTMLHRElement>)}
+    />
+  );
+}
+
+const styles = cva({
+  base: {
+    borderColor: "border.neutral",
+  },
+  variants: {
+    orientation: {
+      horizontal: { width: "100%", height: "0" },
+      vertical: { alignSelf: "stretch", height: "auto", width: "0" },
+    },
+    stroke: {
+      xs: {},
+      sm: {},
+    },
+    variant: {
+      solid: {},
+      dashed: {},
+    },
+  },
+  compoundVariants: [
+    {
+      orientation: "horizontal",
+      stroke: "xs",
+      css: { borderTopWidth: "xs" },
+    },
+    {
+      orientation: "horizontal",
+      stroke: "sm",
+      css: { borderTopWidth: "sm" },
+    },
+    {
+      orientation: "vertical",
+      stroke: "xs",
+      css: { borderLeftWidth: "xs" },
+    },
+    {
+      orientation: "vertical",
+      stroke: "sm",
+      css: { borderLeftWidth: "sm" },
+    },
+    {
+      orientation: "horizontal",
+      variant: "solid",
+      css: { borderTopStyle: "solid" },
+    },
+    {
+      orientation: "horizontal",
+      variant: "dashed",
+      css: { borderTopStyle: "dashed" },
+    },
+    {
+      orientation: "vertical",
+      variant: "solid",
+      css: { borderLeftStyle: "solid" },
+    },
+    {
+      orientation: "vertical",
+      variant: "dashed",
+      css: { borderLeftStyle: "dashed" },
+    },
+  ],
+});

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -1,7 +1,10 @@
 import type { HTMLAttributes, Ref } from "react";
 import { cva, cx } from "../../../styled-system/css";
 
-export interface DividerProps extends HTMLAttributes<HTMLElement> {
+export interface DividerProps extends Omit<
+  HTMLAttributes<HTMLElement>,
+  "children" | "dangerouslySetInnerHTML"
+> {
   /** 방향 */
   orientation?: "horizontal" | "vertical";
   /** 선 스타일 */
@@ -16,6 +19,7 @@ export interface DividerProps extends HTMLAttributes<HTMLElement> {
  * Divider는 콘텐츠를 시각적으로 구분하는 선입니다.
  *
  * - `orientation="horizontal"`(기본값)은 세로로 쌓인 콘텐츠를 가로 선으로 구분할 때, `orientation="vertical"`은 가로로 나열된 콘텐츠를 세로 선으로 구분할 때 사용합니다.
+ * - `orientation="vertical"`은 높이를 `align-self: stretch`로 채우므로 부모가 flex 또는 grid 컨테이너여야 합니다. 그 외의 부모에서는 `align-self`가 무시되어 높이가 0이 되므로, `height` 등으로 직접 높이를 지정해야 합니다.
  */
 export function Divider({
   ref,

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -29,15 +29,13 @@ export function Divider({
   className,
   ...rest
 }: DividerProps) {
-  const lineStyle = styles({ orientation, variant, stroke });
-
   if (orientation === "vertical") {
     return (
       <div
         ref={ref as Ref<HTMLDivElement>}
         role="separator"
         aria-orientation="vertical"
-        className={cx(lineStyle, className)}
+        className={cx(verticalStyles({ variant, stroke }), className)}
         {...(rest as HTMLAttributes<HTMLDivElement>)}
       />
     );
@@ -46,70 +44,45 @@ export function Divider({
   return (
     <hr
       ref={ref as Ref<HTMLHRElement>}
-      className={cx(lineStyle, className)}
+      className={cx(horizontalStyles({ variant, stroke }), className)}
       {...(rest as HTMLAttributes<HTMLHRElement>)}
     />
   );
 }
 
-const styles = cva({
+const horizontalStyles = cva({
   base: {
     borderColor: "border.neutral",
+    width: "100%",
+    height: "0",
   },
   variants: {
-    orientation: {
-      horizontal: { width: "100%", height: "0" },
-      vertical: { alignSelf: "stretch", height: "auto", width: "0" },
-    },
     stroke: {
-      xs: {},
-      sm: {},
+      xs: { borderTopWidth: "xs" },
+      sm: { borderTopWidth: "sm" },
     },
     variant: {
-      solid: {},
-      dashed: {},
+      solid: { borderTopStyle: "solid" },
+      dashed: { borderTopStyle: "dashed" },
     },
   },
-  compoundVariants: [
-    {
-      orientation: "horizontal",
-      stroke: "xs",
-      css: { borderTopWidth: "xs" },
+});
+
+const verticalStyles = cva({
+  base: {
+    borderColor: "border.neutral",
+    alignSelf: "stretch",
+    height: "auto",
+    width: "0",
+  },
+  variants: {
+    stroke: {
+      xs: { borderLeftWidth: "xs" },
+      sm: { borderLeftWidth: "sm" },
     },
-    {
-      orientation: "horizontal",
-      stroke: "sm",
-      css: { borderTopWidth: "sm" },
+    variant: {
+      solid: { borderLeftStyle: "solid" },
+      dashed: { borderLeftStyle: "dashed" },
     },
-    {
-      orientation: "vertical",
-      stroke: "xs",
-      css: { borderLeftWidth: "xs" },
-    },
-    {
-      orientation: "vertical",
-      stroke: "sm",
-      css: { borderLeftWidth: "sm" },
-    },
-    {
-      orientation: "horizontal",
-      variant: "solid",
-      css: { borderTopStyle: "solid" },
-    },
-    {
-      orientation: "horizontal",
-      variant: "dashed",
-      css: { borderTopStyle: "dashed" },
-    },
-    {
-      orientation: "vertical",
-      variant: "solid",
-      css: { borderLeftStyle: "solid" },
-    },
-    {
-      orientation: "vertical",
-      variant: "dashed",
-      css: { borderLeftStyle: "dashed" },
-    },
-  ],
+  },
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export {
   CheckboxGroupItem,
   type CheckboxGroupItemProps,
 } from "./components/CheckboxGroup/CheckboxGroup";
+export { Divider, type DividerProps } from "./components/Divider/Divider";
 export { Flex, type FlexProps } from "./components/Flex/Flex";
 export {
   Grid,

--- a/src/tokens/borders.ts
+++ b/src/tokens/borders.ts
@@ -52,6 +52,8 @@ export const borders: Tokens["borders"] = {
  * borderWidth, outlineWidth
  */
 export const borderWidths: Tokens["borderWidths"] = {
+  // 고밀도(DPR 2+)에서 hairline, DPR 1에서는 1 device px로 올림
+  // https://drafts.csswg.org/css-values-4/#snap-as-a-line-width
   xs: { value: "0.5px" },
   sm: { value: "1px" },
   md: { value: "1.5px" },

--- a/src/tokens/borders.ts
+++ b/src/tokens/borders.ts
@@ -52,6 +52,7 @@ export const borders: Tokens["borders"] = {
  * borderWidth, outlineWidth
  */
 export const borderWidths: Tokens["borderWidths"] = {
+  xs: { value: "0.5px" },
   sm: { value: "1px" },
   md: { value: "1.5px" },
   lg: { value: "2px" },


### PR DESCRIPTION
Divider 컴포넌트를 신규 개발했습니다. stroke xs(0.5px) 지원을 위해 논의대로 borderWidths에 xs: 0.5px 토큰을 추가했습니다.
- orientation : horizontal( `<hr>` ) / vertical(role="separator")
- variant : solid / dashed
- stroke : xs(0.5px) / sm(1px)

## 테스팅
<img width="961" height="640" alt="Screenshot 2026-07-24 at 20 18 08" src="https://github.com/user-attachments/assets/f674cac1-4f8e-4e51-a731-fb58581aeb1b" />
<img width="962" height="697" alt="Screenshot 2026-07-24 at 20 23 34" src="https://github.com/user-attachments/assets/4681ac0a-92ec-4e08-b33d-bf3c19e5624d" />


## 체크 리스트

- [x] 코드 리뷰를 요청하기 전에 반드시 CI가 통과하는지 확인해주세요.
- [x] 컴포넌트나 스토리 변경이 있는 경우 PR에 ui 태그를 달아주세요.
  - [x] UI Tests를 통해 스냅샷 차이가 의도된 것인지 확인해주세요.
  - [x] UI Review를 통해 디자이너에게 리뷰를 요청하고 승인을 받으세요.
