### PR TITLE
Lefthook으로 pre-commit(format·lint), pre-push(test·build) 훅 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ coverage
 # Source maps
 *.map
 
+# Lefthook 로컬 오버라이드
+lefthook-local.yml
+

--- a/bun.lock
+++ b/bun.lock
@@ -36,6 +36,7 @@
         "eslint-plugin-testing-library": "^7.16.2",
         "globals": "^17.7.0",
         "happy-dom": "^20.10.6",
+        "lefthook": "^2.1.10",
         "prettier": "^3.8.5",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
@@ -1240,6 +1241,28 @@
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "lefthook": ["lefthook@2.1.10", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.10", "lefthook-darwin-x64": "2.1.10", "lefthook-freebsd-arm64": "2.1.10", "lefthook-freebsd-x64": "2.1.10", "lefthook-linux-arm64": "2.1.10", "lefthook-linux-x64": "2.1.10", "lefthook-openbsd-arm64": "2.1.10", "lefthook-openbsd-x64": "2.1.10", "lefthook-windows-arm64": "2.1.10", "lefthook-windows-x64": "2.1.10" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-K7mM4WoqMwqfXYK11EHy+lSH1uW8XHni3Yn/bSqyerPkUPygGdf3xn18JoV5HyA06xuQL3ofGAOjG01QX9oJ4w=="],
+
+    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@2.1.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-nw+X8wRNDoUUV6WSteyKBbcLySq+fsmZt5WV/s50ZJpysmsDKJOUMln6SllNfP+60dzUahAO7REco/2633BsLg=="],
+
+    "lefthook-darwin-x64": ["lefthook-darwin-x64@2.1.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-KQ/bHmvpkFdHMn4pZnUdTf+GuSC+aBBgBTxZT4GW+6cSf+qbErKZBhK7cH6BmILsvx43+VzEArvHYY7YOfRFOQ=="],
+
+    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@2.1.10", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-8su6DwydP7+pv7kG0zCtjphqsw4ouOnfexRUErapy5GTxYBoUOhYz3RSHTSWNRsK6W4jva7FPUh2Lp5/PSn30w=="],
+
+    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@2.1.10", "", { "os": "freebsd", "cpu": "x64" }, "sha512-GeAJEFxko3Lk+AsnS3NleAFrpyMLFUKOlgJvPKuU0xHwVEI/z+ZoCcmuO0BX+4CS0NLbZhC/YQAvBASqDvvVdQ=="],
+
+    "lefthook-linux-arm64": ["lefthook-linux-arm64@2.1.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-1sHTCmpTWjVMs+yKPBLRNT1kuuIr1yjietlk7rCB6wFPVOS6Ph3o2zPFH2AvW1UymHlqwyHXzBr9EtDpQ7j1mQ=="],
+
+    "lefthook-linux-x64": ["lefthook-linux-x64@2.1.10", "", { "os": "linux", "cpu": "x64" }, "sha512-z/VlRB3bh6mBvW3r1rwnJ5vP8z+Krx5gJzkZ4veDXh+6FlRTx8wtd3g3fllOv/yZMxkgmL3fQoFXv05Esa7vBQ=="],
+
+    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@2.1.10", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-430zL8sSIKw5P0YXGG6PB+eAhHa06n0PXuaERaAQE4Ss3odfqwnl5Mq9hQmkEnOS1EGiQEKkd0UHv/i4PtMNIQ=="],
+
+    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@2.1.10", "", { "os": "openbsd", "cpu": "x64" }, "sha512-bgkO8PphGZVDhQgCJ524aYYPI5491pVmCiLPGjBIo1AvOSlIyw4N1Y+1C3QfqwEmechzw+Aq16SNc8pqv6UuXg=="],
+
+    "lefthook-windows-arm64": ["lefthook-windows-arm64@2.1.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-5Q6etF0Fla2DDA4ilDySrdNgiR5+W7cJZwnZ69Je3kvWCaWm4wnkuc8FEdjp3kiL2x3ZXipdI00f5vpO8aWmog=="],
+
+    "lefthook-windows-x64": ["lefthook-windows-x64@2.1.10", "", { "os": "win32", "cpu": "x64" }, "sha512-c/XH8YZtylG4XaxzqFfXluvq2LXq2W/p54Bnzn3+Z7E5X2Fk3JlFJAibulMbIt2+w8T7UI/r97ok5GqE4kGaeA=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,24 @@
+# Lefthook 설정 — https://lefthook.dev
+#
+# pre-commit: staged 파일만 자동 수정(eslint --fix → prettier --write) 후 재-stage.
+#             둘 다 같은 파일을 수정하므로 순차 실행(키 알파벳순: eslint → prettier).
+# pre-push:   전체 test·build 검증. 둘 다 읽기 전용이라 병렬(parallel) 안전.
+
+pre-commit:
+  commands:
+    eslint:
+      glob: "*.{ts,tsx,js,jsx,cjs,mjs}"
+      run: bunx eslint --fix --no-warn-ignored {staged_files}
+      stage_fixed: true
+    prettier:
+      glob: "*.{ts,tsx,js,jsx,cjs,mjs,css,json,jsonc,md,mdx,yml,yaml,html}"
+      run: bunx prettier --write --ignore-unknown {staged_files}
+      stage_fixed: true
+
+pre-push:
+  parallel: true
+  commands:
+    test:
+      run: bunx vitest run
+    build:
+      run: bun run build

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "sb": "storybook dev -p 6006",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "prepare": "panda codegen"
+    "prepare": "panda codegen && lefthook install"
   },
   "peerDependencies": {
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
@@ -83,6 +83,7 @@
     "eslint-plugin-testing-library": "^7.16.2",
     "globals": "^17.7.0",
     "happy-dom": "^20.10.6",
+    "lefthook": "^2.1.10",
     "prettier": "^3.8.5",
     "storybook": "^10.4.6",
     "typescript": "^6.0.3",


### PR DESCRIPTION
Closes #869

로컬에 git hook이 없다 보니 format·lint 오류를 CI에서야 발견하고 다시 고쳐 push하는 일이 반복됐습니다. Lefthook을 붙여 커밋·푸시 전에 로컬에서 먼저 걸러내도록 했습니다.

주요 변경은 다음과 같습니다.

- `lefthook`을 devDependency로 추가하고 `prepare` 스크립트에 `lefthook install`을 이어 붙였습니다. 기존 `panda codegen`은 그대로 두었으니 `bun install` 한 번이면 훅까지 설치됩니다.
- `pre-commit`은 staged 파일만 대상으로 `eslint --fix` 다음 `prettier --write`를 실행합니다. 둘이 같은 파일을 고치므로 병렬로 두지 않았고, lefthook이 커맨드를 키 이름 순으로 돌리기 때문에 자연히 `eslint` → `prettier` 순서가 됩니다. `stage_fixed: true`를 줘서 자동 수정된 내용이 그대로 커밋에 들어갑니다.
- `pre-push`는 `vitest run`과 `bun run build`를 병렬로 실행합니다. 둘 다 소스를 건드리지 않아 병렬이 안전하고, 로컬에서 5초 정도 걸립니다.
- `.gitignore`에 `lefthook-local.yml`을 추가했습니다. 개인 훅 오버라이드 파일인데 기존 `*.local` 패턴에 걸리지 않아 실수로 커밋될 수 있었습니다.

이슈 본문에는 pre-commit만 적혀 있는데 pre-push까지 넣었습니다. 커밋 단계에서 format·lint만 잡으면 테스트나 빌드가 깨진 채로 push되는 건 그대로라, 이슈가 말한 CI 실패 감소를 보려면 push 시점 검증도 같이 있어야 한다고 봤습니다. 범위를 넘는다고 판단하시면 pre-push는 덜어내겠습니다.

훅을 건너뛰어야 할 때는 `LEFTHOOK=0 git commit ...`이나 `--no-verify`를 쓰면 됩니다.

## 테스팅

로컬에서 훅을 직접 돌려 확인했습니다. 포맷이 깨진 `.ts` 파일을 stage하고 커밋하니 eslint와 prettier가 고쳐 다시 stage했고, 커밋된 결과물은 포맷이 맞춰진 상태였습니다. 반대로 자동 수정이 안 되는 `@typescript-eslint/no-explicit-any` 오류가 있는 파일은 커밋이 중단되고 HEAD도 그대로 남았습니다. pre-push는 이 브랜치를 실제로 push할 때 돌아서 test와 build 모두 통과했고, 5초 정도 걸렸습니다.

락파일은 CI와 같은 `bun install --frozen-lockfile`로 정합성을 확인했습니다.

## 체크 리스트

- [x] 코드 리뷰를 요청하기 전에 반드시 CI가 통과하는지 확인해주세요.
- [ ] 컴포넌트나 스토리 변경이 있는 경우 PR에 ui 태그를 달아주세요.
  - [ ] UI Tests를 통해 스냅샷 차이가 의도된 것인지 확인해주세요.
  - [ ] UI Review를 통해 디자이너에게 리뷰를 요청하고 승인을 받으세요.

