### PR TITLE
fork PR에서 Chromatic 실행 제외

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -39,8 +39,10 @@ jobs:
     needs: changes
     # ui 라벨이 있거나 UI 경로가 바뀌면 실행, main push·수동 실행은 항상.
     # push/workflow_dispatch일 땐 changes가 skip이라 !cancelled()로 풀어준다.
+    # fork PR은 secrets가 전달되지 않아 Chromatic이 반드시 실패하므로 제외한다.
     if: >-
       !cancelled() &&
+      github.event.pull_request.head.repo.fork != true &&
       (github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'ui') ||


### PR DESCRIPTION
<!-- PR에 대해 알아야 하는 내용은 위키의 컨벤션을 확인해 주세요.
위키 - https://github.com/DaleStudy/daleui/wiki/Conventions -->

<!-- 무엇을 왜 변경했나요? (예: 접근성 개선을 위해 Button 컴포넌트에 disabled prop 추가) -->
fork 저장소에서 올라온 PR은 GitHub Actions secrets에 접근할 수 없어 CHROMATIC_PROJECT_TOKEN이 전달되지 않고, Chromatic check가 항상 실패합니다.
#1224 (부모티켓) 논의결과, fork PR에서는 Chromatic 실행을 제외하고, UI 확인이 필요한 경우에는 maintainer가 upstream branch에서 별도로 검증하는 방식으로 진행할 예정입니다. 이에 따라서 업데이트된 외부 기여 UI 확인 프로세스는 #1245에서 위키에 반영했으며, 이 PR에서는 그에 따른 워크플로우 변경을 적용합니다.

`chromatic.yml`의 `pre-chromatic` 실행 조건에 한 줄을 추가했습니다.

```yaml
github.event.pull_request.head.repo.fork != true &&
```
## 체크 리스트

- [x] 코드 리뷰를 요청하기 전에 반드시 CI가 통과하는지 확인해주세요.
