### PR TITLE
미팅 운영 방식 및 회의 템플릿 개선

### DIFF
--- a/.github/meeting-templates/end-sprint.md
+++ b/.github/meeting-templates/end-sprint.md
@@ -1,13 +1,30 @@
 # Sprint {{SPRINT_NUMBER}} 종료 회의
 
-## 데모 및 안건 (30분)
+> 기본 1시간, 필요한 경우 최대 1시간 30분
 
-> 각 주제에는 **예상 소요 시간**과 **담당자**를 멘션해주세요. (예: `[15분] 디자인 데모 @DaleSeo`)
+## Sprint Goal
+
+> 이번 스프린트 목표와 실제 결과를 확인합니다.
+
+- 목표:
+- 결과: 달성 / 부분 달성 / 미달성
+- 참고:
+
+> 보드: https://github.com/orgs/DaleStudy/projects/18
+
+## 데모 및 안건
+
+> 각 주제에는 **예상 소요 시간**과 **담당자**를 멘션해주세요.  
+> 예: `[15분] Card 컴포넌트 데모 @daleSeo`
 
 -
 
-## 플래닝/그루밍 (30분)
+## 회고
 
-> 미완료 티켓 이관, 백로그 우선순위 정립, 다음 목표 수립
+> 이번 스프린트를 돌아보고 다음 스프린트에 이어갈 점과 개선할 점을 이야기합니다.  
+> 회고보드: https://www.figma.com/board/ih9UMQURdnckAA52IBOtKV/DaleUI-Retro?node-id=1347-464&t=BEkcgmD0gNsMB8dq-1
 
-- 보드: https://github.com/orgs/DaleStudy/projects/18
+## 플래닝 / 그루밍
+
+> 마무리되지 않은 티켓을 정리하고, 백로그와 우선순위를 확인한 뒤 다음 스프린트 목표와 가져갈 티켓을 정합니다.  
+> 보드: https://github.com/orgs/DaleStudy/projects/18

--- a/.github/meeting-templates/mid-sprint.md
+++ b/.github/meeting-templates/mid-sprint.md
@@ -1,11 +1,19 @@
 # Sprint {{SPRINT_NUMBER}} 중간 회의
 
-## 데모 및 안건 (30분)
+> 기본 30분, 데모나 별도 안건이 있는 경우 최대 1시간
 
-> 각 주제에는 **예상 소요 시간**과 **담당자**를 멘션해주세요. (예: `[15분] 리서치 공유 @DaleSeo`)
+## Sprint Goal
+
+> 이번 스프린트 목표를 기준으로 현재 진행 상황을 점검합니다.
+
+- 목표:
+- 진행 상황:
+
+> 보드: https://github.com/orgs/DaleStudy/projects/18
+
+## 데모 및 안건
+
+> 각 주제에는 **예상 소요 시간**과 **담당자**를 멘션해주세요.  
+> 예: `[15분] Card 컴포넌트 데모 @daleSeo`
 
 -
-
-## 회고 (30분)
-
-- 회고보드: https://www.figma.com/board/ih9UMQURdnckAA52IBOtKV/DaleUI-Retro?node-id=1347-464&t=BEkcgmD0gNsMB8dq-1

--- a/.github/workflows/create-meeting-issue.yml
+++ b/.github/workflows/create-meeting-issue.yml
@@ -38,6 +38,7 @@ jobs:
           SPRINT_NUMBER=$(( SPRINT_START_NUMBER + (DAYS_DIFF / 14) ))
           WEEK_IN_CYCLE=$(( (DAYS_DIFF % 14) / 7 ))
 
+          # 제목 형식 변경 금지 — 리마인더의 정규식과 불참 공유 쓰레드 이름이 이 형식에 의존함
           if [ "$WEEK_IN_CYCLE" -eq 0 ]; then
             echo "type=mid" >> $GITHUB_OUTPUT
             echo "title=Sprint ${SPRINT_NUMBER} 중간 회의" >> $GITHUB_OUTPUT
@@ -65,39 +66,43 @@ jobs:
 
       - name: Create GitHub issue
         if: steps.meeting-info.outputs.type != 'skip'
-        id: create-issue # 다음 스텝에서 issue_url 참조하기 위해 id 부여
+        id: create-issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TITLE: ${{ steps.meeting-info.outputs.title }}
         run: |
-          # gh issue create는 생성된 이슈 URL을 stdout으로 출력함
           ISSUE_URL=$(gh issue create \
             --title "$TITLE" \
             --body-file /tmp/issue-body.md)
-          # GITHUB_OUTPUT에 저장해 다음 스텝에서 ${{ steps.create-issue.outputs.issue_url }}로 사용
           echo "issue_url=$ISSUE_URL" >> $GITHUB_OUTPUT
 
       - name: Create Discord scheduled event
         if: steps.meeting-info.outputs.type != 'skip'
-        id: create-event # 다음 스텝에서 event_id 참조하기 위해 id 부여
+        id: create-event
         env:
           DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
           DISCORD_GUILD_ID: ${{ vars.DISCORD_GUILD_ID }}
+          MEETING_TYPE: ${{ steps.meeting-info.outputs.type }}
           TITLE: ${{ steps.meeting-info.outputs.title }}
           ISSUE_URL: ${{ steps.create-issue.outputs.issue_url }}
         run: |
           # 워크플로우는 현재 회의 종료 시점(토 01:30 UTC)에 실행됨
-          # Discord 이벤트는 7일 후 다음 회의(토 00:30 UTC = 금 8:30 PM EDT / 토 9:30 AM KST)로 설정
+          # 이벤트는 7일 후 다음 회의(토 00:30 UTC = 금 8:30 PM EDT / 토 9:30 AM KST)로 설정
           NEXT_SAT=$(date -d "+7 days" +%Y-%m-%d)
-          START_TIME="${NEXT_SAT}T00:30:00+00:00"  # 금 8:30 PM EDT / 토 9:30 AM KST
-          END_TIME="${NEXT_SAT}T01:30:00+00:00"    # 금 9:30 PM EDT / 토 10:30 AM KST (1시간 회의)
+          START_TIME="${NEXT_SAT}T00:30:00+00:00"
+          START_UNIX=$(date -d "$START_TIME" +%s)
 
-          # Discord API: Scheduled Event 생성
+          # 회의 유형별 기본 소요 시간 (최대 시간은 회의록 상단 안내로만 표기)
+          if [ "$MEETING_TYPE" = "mid" ]; then
+            DURATION_MIN=30
+          else
+            DURATION_MIN=60
+          fi
+          END_TIME=$(date -u -d "@$(( START_UNIX + DURATION_MIN * 60 ))" +%Y-%m-%dT%H:%M:%S+00:00)
+
           # entity_type 3 = EXTERNAL (외부 링크 기반, RSVP 지원, 타임존별 시간 자동 표시)
           # privacy_level 2 = GUILD_ONLY (서버 멤버만 볼 수 있음)
           # entity_metadata.location = 회의록 이슈 URL (이벤트 상세에서 클릭 가능)
-          START_UNIX=$(date -d "${NEXT_SAT}T00:30:00+00:00" +%s)
-
           RESPONSE=$(curl -sf --show-error -X POST \
             "https://discord.com/api/v10/guilds/${DISCORD_GUILD_ID}/scheduled-events" \
             -H "Authorization: Bot ${DISCORD_TOKEN}" \
@@ -113,13 +118,13 @@ jobs:
               }
             }")
 
-          # 생성된 이벤트 ID 추출 → 채널 공지 스텝에서 이벤트 링크 생성에 사용
           EVENT_ID=$(echo "$RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
           echo "event_id=$EVENT_ID" >> $GITHUB_OUTPUT
           echo "start_unix=$START_UNIX" >> $GITHUB_OUTPUT
 
       - name: Send channel announcement
         if: steps.meeting-info.outputs.type != 'skip'
+        id: announce
         env:
           DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
           DISCORD_GUILD_ID: ${{ vars.DISCORD_GUILD_ID }}
@@ -132,11 +137,43 @@ jobs:
         run: |
           EVENT_LINK="https://discord.com/events/${DISCORD_GUILD_ID}/${EVENT_ID}"
 
-          # 디자인시스템-채팅 채널에 회의 일정 공지 및 RSVP 유도 메시지 전송
-          curl -sf --show-error -X POST \
+          RESPONSE=$(curl -sf --show-error -X POST \
             "https://discord.com/api/v10/channels/${DISCORD_DALEUI_CHAT_CHANNEL_ID}/messages" \
             -H "Authorization: Bot ${DISCORD_TOKEN}" \
             -H "Content-Type: application/json" \
             -d "{
-              \"content\": \"<@&${DISCORD_DALEUI_ROLE_ID}>\n\n📅 **${TITLE}** 일정이 등록되었습니다.\n\n<t:${START_UNIX}:F> (<t:${START_UNIX}:R>)\n📋 [회의록](${ISSUE_URL})\n\n[이벤트](${EVENT_LINK})에서 **Interested** 눌러 참석 여부를 알려주세요!\n불참 시에는 이 메시지 쓰레드에 남겨주세요 🙏\"
-            }"
+              \"content\": \"<@&${DISCORD_DALEUI_ROLE_ID}>\n\n📅 **${TITLE}** 일정이 등록되었습니다.\n\n<t:${START_UNIX}:F> (<t:${START_UNIX}:R>)\n📋 [회의록](${ISSUE_URL})\n\n참석 예정이라면 [이벤트](${EVENT_LINK})에서 **Interested**를 눌러주세요.\n불참하시는 분은 아래 **불참 공유** 쓰레드에 남겨주세요!\"
+            }")
+
+          # 다음 스텝에서 이 메시지에 불참 공유 쓰레드를 붙이는 데 사용함
+          MESSAGE_ID=$(echo "$RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
+          echo "message_id=$MESSAGE_ID" >> $GITHUB_OUTPUT
+
+      - name: Create absence thread
+        if: steps.meeting-info.outputs.type != 'skip'
+        env:
+          DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
+          DISCORD_DALEUI_CHAT_CHANNEL_ID: ${{ vars.DISCORD_DALEUI_CHAT_CHANNEL_ID }}
+          TITLE: ${{ steps.meeting-info.outputs.title }}
+          MESSAGE_ID: ${{ steps.announce.outputs.message_id }}
+        run: |
+          # 불참 공유가 채널·리마인더로 흩어지지 않도록 공지 메시지에 쓰레드를 미리 만들어 둠
+          # 10080분(7일) = 다음 회의까지 유지 (메시지가 달릴 때마다 갱신됨)
+          curl -sf --show-error -X POST \
+            "https://discord.com/api/v10/channels/${DISCORD_DALEUI_CHAT_CHANNEL_ID}/messages/${MESSAGE_ID}/threads" \
+            -H "Authorization: Bot ${DISCORD_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"name\": \"${TITLE} - 불참 공유\",
+              \"auto_archive_duration\": 10080
+            }" > /dev/null
+
+          # 메시지에서 시작한 쓰레드의 ID는 원본 메시지 ID와 동일함
+          # 역할 멘션은 채널 공지·리마인더에만 두어 같은 내용으로 두 번 알림이 가지 않게 함
+          curl -sf --show-error -X POST \
+            "https://discord.com/api/v10/channels/${MESSAGE_ID}/messages" \
+            -H "Authorization: Bot ${DISCORD_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"content\": \"**${TITLE}** 불참 공유 쓰레드입니다.\n\n참석 예정은 이벤트의 **Interested**로 확인하고,\n불참하시는 경우에는 이곳에 남겨주세요.\"
+            }" > /dev/null

--- a/.github/workflows/send-meeting-reminder.yml
+++ b/.github/workflows/send-meeting-reminder.yml
@@ -92,6 +92,34 @@ jobs:
           echo "event_id=$EVENT_ID" >> "$GITHUB_OUTPUT"
           echo "start_unix=$(date -d "$START_ISO" +%s)" >> "$GITHUB_OUTPUT"
 
+      - name: Find absence thread
+        if: steps.find-issue.outputs.found == 'true'
+        id: find-thread
+        env:
+          DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
+          DISCORD_GUILD_ID: ${{ vars.DISCORD_GUILD_ID }}
+          DISCORD_DALEUI_CHAT_CHANNEL_ID: ${{ vars.DISCORD_DALEUI_CHAT_CHANNEL_ID }}
+          TITLE: ${{ steps.find-issue.outputs.title }}
+        run: |
+          RESPONSE=$(curl -sf --show-error \
+            "https://discord.com/api/v10/guilds/${DISCORD_GUILD_ID}/threads/active" \
+            -H "Authorization: Bot ${DISCORD_TOKEN}")
+
+          # 공지 메시지에 달린 "<회의명> - 불참 공유" 쓰레드
+          # 못 찾아도 실패시키지 않음 — 리마인더에서 링크 줄만 빠짐
+          echo "$RESPONSE" | python3 -c '
+          import json, os, sys
+
+          threads = json.load(sys.stdin).get("threads", [])
+          name = os.environ["TITLE"] + " - 불참 공유"
+          channel = os.environ["DISCORD_DALEUI_CHAT_CHANNEL_ID"]
+          match = next(
+              (t for t in threads if t["name"] == name and t["parent_id"] == channel),
+              None,
+          )
+          print("thread_id=" + (match["id"] if match else ""))
+          ' >> "$GITHUB_OUTPUT"
+
       - name: Send reminder message
         if: steps.find-issue.outputs.found == 'true'
         env:
@@ -102,6 +130,7 @@ jobs:
           MANUAL_DAYS_BEFORE: ${{ inputs.days_before }}
           TITLE: ${{ steps.find-issue.outputs.title }}
           ISSUE_URL: ${{ steps.find-issue.outputs.issue_url }}
+          THREAD_ID: ${{ steps.find-thread.outputs.thread_id }}
           EVENT_ID: ${{ steps.find-event.outputs.event_id }}
           START_UNIX: ${{ steps.find-event.outputs.start_unix }}
         run: |
@@ -115,12 +144,19 @@ jobs:
             DAYS_LEFT=$(( (SECONDS_LEFT + 86399) / 86400 ))   # 올림 처리로 "몇 밤 남았나" 계산
           fi
 
-          if [ "$DAYS_LEFT" -le 1 ]; then
-            HEADER="🔔 **${TITLE}**가 내일이에요!"
-            CTA="데모/안건이 있으면 회의록에 미리 남겨주세요. [이벤트](${EVENT_LINK})에서 참석 여부도 꼭 확인해주세요!"
+          # 쓰레드를 못 찾은 경우 이 줄만 빠지고 본문 안내는 그대로 나감
+          if [ -n "$THREAD_ID" ]; then
+            THREAD_LINE="\n💬 [불참 공유](https://discord.com/channels/${DISCORD_GUILD_ID}/${THREAD_ID})"
           else
-            HEADER="⏰ **${TITLE}**가 ${DAYS_LEFT}일 후로 다가왔어요!"
-            CTA="아직 참석 여부를 남기지 않으셨다면 [이벤트](${EVENT_LINK})에서 **Interested** 를 눌러주세요. 데모/안건이 있으면 회의록에 미리 남겨주세요!"
+            THREAD_LINE=""
+          fi
+
+          if [ "$DAYS_LEFT" -le 1 ]; then
+            HEADER="🔔 **${TITLE}**가 내일입니다!"
+            BODY="마지막으로 한 번만 확인해주세요!\n- 참석 예정 → [이벤트](${EVENT_LINK}) **Interested**\n- 불참 → **불참 공유**\n- 데모·안건 → **회의록**"
+          else
+            HEADER="⏰ **${TITLE}**가 ${DAYS_LEFT}일 후입니다!"
+            BODY="아직 참석 여부를 남기지 않으셨다면 [이벤트](${EVENT_LINK})에서 **Interested**를 눌러주세요.\n불참하시는 분은 쓰레드에, 데모나 안건이 있다면 회의록에 미리 남겨주세요!"
           fi
 
           curl -sf --show-error -X POST \
@@ -128,5 +164,5 @@ jobs:
             -H "Authorization: Bot ${DISCORD_TOKEN}" \
             -H "Content-Type: application/json" \
             -d "{
-              \"content\": \"<@&${DISCORD_DALEUI_ROLE_ID}>\n\n${HEADER}\n\n<t:${START_UNIX}:F> (<t:${START_UNIX}:R>)\n📋 [회의록](${ISSUE_URL})\n\n${CTA}\"
+              \"content\": \"<@&${DISCORD_DALEUI_ROLE_ID}>\n\n${HEADER}\n\n<t:${START_UNIX}:F> (<t:${START_UNIX}:R>)\n📋 [회의록](${ISSUE_URL})${THREAD_LINE}\n\n${BODY}\"
             }"


### PR DESCRIPTION
<!-- 무엇을 왜 변경했나요? (예: 접근성 개선을 위해 Button 컴포넌트에 disabled prop 추가) -->
중간/종료 회의 운영 방식을 조정하면서 회의록 템플릿과 Discord 알림 흐름도 함께 정리했습니다.

## 변경 내용

기존에는 중간 회의에서 회고까지 함께 진행하고, 중간/종료 회의 모두 1시간(최대 1시간 반) 기준으로 운영했습니다.  
이번에는 중간 회의를 스프린트 목표 중심의 점검 자리로 더 컴팩트하게 가져가고, 회고는 스프린트를 마무리하는 종료 회의에서 진행하도록 흐름을 조정했습니다. 동시에 불참 여부도 한곳에서 중앙화해서 확인할 수 있도록 Discord 불참 공유 쓰레드를 추가했습니다.

이에 맞춰 아래 내용을 변경했습니다.
- 중간 회의 기본 시간을 1시간 → 30분으로 조정하고, Discord 일정 길이도 동일하게 반영
- 회고를 중간 회의 → 종료 회의로 이동
- 중간/종료 회의 모두 Sprint Goal을 확인할 수 있도록 회의록 템플릿 수정
- 종료 회의는 기존 1시간 기준을 유지하고 Discord 일정에도 동일하게 반영
- Discord 불참 공유 쓰레드 추가
  - 불참을 별도 쓰레드에 남길 수 있도록 안내하고 쓰레드를 자동 생성(기존에는 리마인더, 채널에 흩어짐)
  - 3일 전/1일 전 리마인더와 회의록에서도 불참 공유 쓰레드 링크 제공

## 검증
- 워크플로우가 주 1회 실행되어 CI로 직접 검증하기 어려워, 각 스텝의 스크립트를 추출하고 `curl`과 `gh`를 스텁으로 대체해 로컬에서 확인했습니다.
- `DISCORD_TOKEN`은 DaleStudy/community-manager의 주간 업데이트 봇에서 동일 채널의 메시지 기반 쓰레드 생성에 이미 사용하고 있어 별도 권한 설정 없이 동작합니다.

## 체크 리스트

- [x] 코드 리뷰를 요청하기 전에 반드시 CI가 통과하는지 확인해주세요.

<!-- UI Review 및 UI Tests에 대한 내용은 상단 컨벤션 문서의 '7. PR리뷰 및 병합' 내용을 참고해 주세요. -->
