### PR TITLE
Avatar 개발

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -24,6 +24,7 @@
 
 상세 props → [components.md](https://github.com/DaleStudy/daleui/blob/main/skills/daleui/components.md)
 
+- Avatar: `import { Avatar } from "daleui"`. 아바타(Avatar)는 현재 로그인한 사용자나 콘텐츠 작성자의 프로필 이미지를 동그라미나 네모 형태로 시각화하고(사용자 식별 기능), 이미지가 없을 때는 이름의 이니셜이나 기본 아이콘을 대신 보여주어(대체 정보 제공) 서비스 내에서 사용자의 고유한 정체성과 소속감을 직관적으로 표현해 주는 기본 컴포넌트입니다.
 - Box: `import { Box } from "daleui"`. Box는 가장 기본적인 레이아웃 컴포넌트입니다.
 - Button: `import { Button } from "daleui"`. 버튼은 사용자의 명확한 작업 실행을 위해 사용되는 컴포넌트로, 완료, 저장, 제출과 같은 액션에 사용합니다.
 - Card: `import { Card } from "daleui"`. Card의 최상위 컨테이너입니다. `tone`은 하위 `Card.Icon`과 `Card.Link`에 자동으로 전달됩니다.

--- a/skills/daleui/components.md
+++ b/skills/daleui/components.md
@@ -2,6 +2,94 @@
 
 > 자동 생성 — 수동 편집하지 마세요.
 
+## Avatar
+
+아바타(Avatar)는 현재 로그인한 사용자나 콘텐츠 작성자의 프로필 이미지를 동그라미나 네모 형태로 시각화하고(사용자 식별 기능), 이미지가 없을 때는 이름의 이니셜이나 기본 아이콘을 대신 보여주어(대체 정보 제공) 서비스 내에서 사용자의 고유한 정체성과 소속감을 직관적으로 표현해 주는 기본 컴포넌트입니다.
+
+`src`가 있으면 이미지를, 없거나 불러오기에 실패하면 `name`으로 만든 이니셜을, 둘 다 없으면 대체 아이콘을 표시합니다.
+
+**이니셜 규칙**
+한 글자만으로 구분되는 한글·한자·가나는 첫 글자만, 영문은 두 글자를 사용합니다.
+
+- `"서달레"` → `"서"`
+- `"Dale Seo"` → `"DS"` (공백으로 나뉘면 각 단어의 첫 글자)
+- `"dale"` → `"DA"` (한 단어면 앞 두 글자)
+
+**접근성(Accessibility) 안내**
+
+- `name`이 있으면 이미지의 대체 텍스트로 쓰입니다.
+- `name`이 없으면 읽을 이름이 없어 아무것도 읽히지 않습니다.
+- 이름이 필요한 자리(아바타만 있는 버튼, 아바타 묶음 등)에는 `aria-label`이나
+  `aria-labelledby`를 직접 넘기면 그 이름으로 읽힙니다.
+
+`import { Avatar } from "daleui"`
+
+| prop | 타입                   | 기본값 | 설명                                                                                 |
+| ---- | ---------------------- | ------ | ------------------------------------------------------------------------------------ |
+| src  | `string`               | -      | 이미지 주소. 비어 있거나 불러오기에 실패하면 이니셜 → 대체 아이콘 순으로 표시됩니다. |
+| name | `string`               | -      | 사용자 이름. 이니셜을 만드는 데 쓰이고 이미지의 대체 텍스트가 됩니다.                |
+| size | `AvatarSize`           | `"md"` | 크기. `sm`은 32px, `md`는 40px, `lg`는 48px입니다.                                   |
+| ref  | `Ref<HTMLSpanElement>` | -      | 요소 참조                                                                            |
+
+### 예시
+
+**Variants**
+
+```tsx
+<Grid gridTemplateColumns="repeat(3, auto)" gap="24" justifyItems="start">
+  <Text size="md" muted>
+    image
+  </Text>
+  <Text size="md" muted>
+    initial
+  </Text>
+  <Text size="md" muted>
+    fallback
+  </Text>
+  <Avatar name="서달레" src={sampleImage} />
+  <Avatar name="서달레" src="" />
+  <Avatar src="" />
+</Grid>
+```
+
+**Sizes**
+
+```tsx
+<HStack gap="24" align="bottom">
+  {sizes.map((size) => (
+    <VStack key={size} gap="8" align="left">
+      <Text size="md" muted>
+        {size}
+      </Text>
+      <Avatar name="서달레" size={size} />
+    </VStack>
+  ))}
+</HStack>
+```
+
+**Initials**
+
+```tsx
+<HStack gap="24" align="top">
+  {[
+    { name: "서달레", note: "한글 → 첫 글자" },
+    { name: "Dale Seo", note: "영문 두 단어 → 각 첫 글자" },
+    { name: "dale", note: "영문 한 단어 → 앞 두 글자" },
+    { name: "山田太郎", note: "한자 → 첫 글자" },
+  ].map(({ name, note }) => (
+    <VStack key={name} gap="8" align="left">
+      <Text size="md" muted>
+        {note}
+      </Text>
+      <HStack gap="8">
+        <Avatar size="lg" src="" name={name} />
+        <Text size="md">{name}</Text>
+      </HStack>
+    </VStack>
+  ))}
+</HStack>
+```
+
 ## Box
 
 Box는 가장 기본적인 레이아웃 컴포넌트입니다.

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Grid } from "../Grid/Grid";
+import { HStack } from "../HStack/HStack";
+import { Text } from "../Text/Text";
+import { VStack } from "../VStack/VStack";
+import { Avatar, type AvatarSize } from "./Avatar";
+
+const sizes: AvatarSize[] = ["sm", "md", "lg"];
+
+const sampleImage = "https://avatars.githubusercontent.com/u/5466341?v=4&s=100";
+
+export default {
+  component: Avatar,
+  title: "Components/Avatar",
+  parameters: {
+    layout: "centered",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/mQ2ETYC6LXGOwVETov3CgO/DaleUI-Kit?node-id=9560-215",
+    },
+  },
+  args: {
+    src: "",
+    name: "서달레",
+    size: "md",
+  },
+  argTypes: {
+    src: { control: "text" },
+    name: { control: "text" },
+    size: { control: "inline-radio", options: sizes },
+  },
+} satisfies Meta<typeof Avatar>;
+
+type Story = StoryObj<typeof Avatar>;
+
+export const Basic: Story = {};
+
+export const Variants: Story = {
+  render: (args) => (
+    <Grid gridTemplateColumns="repeat(3, auto)" gap="24" justifyItems="start">
+      <Text size="md" muted>
+        image
+      </Text>
+      <Text size="md" muted>
+        initial
+      </Text>
+      <Text size="md" muted>
+        fallback
+      </Text>
+      <Avatar {...args} src={sampleImage} />
+      <Avatar {...args} src="" />
+      <Avatar {...args} src="" name={undefined} />
+    </Grid>
+  ),
+  argTypes: {
+    src: { control: false },
+  },
+};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <HStack gap="24" align="bottom">
+      {sizes.map((size) => (
+        <VStack key={size} gap="8" align="left">
+          <Text size="md" muted>
+            {size}
+          </Text>
+          <Avatar {...args} size={size} />
+        </VStack>
+      ))}
+    </HStack>
+  ),
+  argTypes: {
+    size: { control: false },
+  },
+};
+
+export const Initials: Story = {
+  args: {
+    size: "lg",
+  },
+  render: (args) => (
+    <HStack gap="24" align="top">
+      {[
+        { name: "서달레", note: "한글 → 첫 글자" },
+        { name: "Dale Seo", note: "영문 두 단어 → 각 첫 글자" },
+        { name: "dale", note: "영문 한 단어 → 앞 두 글자" },
+        { name: "山田太郎", note: "한자 → 첫 글자" },
+      ].map(({ name, note }) => (
+        <VStack key={name} gap="8" align="left">
+          <Text size="md" muted>
+            {note}
+          </Text>
+          <HStack gap="8">
+            <Avatar {...args} src="" name={name} />
+            <Text size="md">{name}</Text>
+          </HStack>
+        </VStack>
+      ))}
+    </HStack>
+  ),
+  argTypes: {
+    src: { control: false },
+    name: { control: false },
+  },
+};

--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -1,0 +1,245 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { Avatar } from "./Avatar";
+import { getInitial } from "./getInitial";
+
+/** 장식으로 두는 안쪽 이미지(alt="")와 아이콘은 접근성 트리에 없어 DOM에서 직접 찾습니다. */
+function getImage(container: HTMLElement) {
+  return container.querySelector("img");
+}
+
+function getFallbackIcon(container: HTMLElement) {
+  return container.querySelector("svg");
+}
+
+describe("Avatar 이미지", () => {
+  test("src가 있으면 이미지를 렌더링하고 name이 그 이름이 됨", () => {
+    const { container } = render(<Avatar src="/dale.png" name="서달레" />);
+
+    expect(screen.getByRole("img")).toHaveAccessibleName("서달레");
+    expect(getImage(container)).toHaveAttribute("src", "/dale.png");
+  });
+
+  test("name이 없으면 이미지의 대체 텍스트가 비어 있음", () => {
+    const { container } = render(<Avatar src="/dale.png" />);
+
+    expect(getImage(container)).toHaveAttribute("alt", "");
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  test("이미지 불러오기에 실패하면 이니셜로 대체됨", () => {
+    const { container } = render(
+      <Avatar src="/없는-이미지.png" name="서달레" />,
+    );
+
+    fireEvent.error(getImage(container)!);
+
+    expect(getImage(container)).not.toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "서달레" })).toHaveTextContent("서");
+  });
+
+  test("이미지 불러오기에 실패하고 name도 없으면 대체 아이콘으로 대체됨", () => {
+    const { container } = render(<Avatar src="/없는-이미지.png" />);
+
+    fireEvent.error(getImage(container)!);
+
+    expect(getImage(container)).not.toBeInTheDocument();
+    expect(getFallbackIcon(container)).toBeInTheDocument();
+  });
+
+  test("1px 테두리는 모든 표시 형태에 있어 안쪽 크기가 같고, 링은 이미지에만 보임", () => {
+    render(<Avatar src="/dale.png" name="서달레" data-testid="image" />);
+    render(<Avatar name="서달레" data-testid="initial" />);
+    render(<Avatar data-testid="fallback" />);
+
+    expect(screen.getByTestId("image")).toHaveClass("bd_brand");
+    expect(screen.getByTestId("initial")).toHaveClass("bd_brand");
+    expect(screen.getByTestId("fallback")).toHaveClass("bd_brand");
+
+    expect(screen.getByTestId("image")).not.toHaveClass("bd-c_transparent");
+    expect(screen.getByTestId("initial")).toHaveClass("bd-c_transparent");
+    expect(screen.getByTestId("fallback")).toHaveClass("bd-c_transparent");
+  });
+
+  test("src가 바뀌면 실패했던 이미지와 무관하게 다시 시도함", () => {
+    const { container, rerender } = render(
+      <Avatar src="/실패.png" name="서달레" />,
+    );
+
+    fireEvent.error(getImage(container)!);
+    expect(getImage(container)).not.toBeInTheDocument();
+
+    rerender(<Avatar src="/성공.png" name="서달레" />);
+
+    expect(getImage(container)).toHaveAttribute("src", "/성공.png");
+  });
+});
+
+describe("Avatar 이니셜", () => {
+  test("src가 없고 name이 있으면 이니셜을 보여줌", () => {
+    render(<Avatar name="Dale Seo" />);
+
+    expect(screen.getByRole("img", { name: "Dale Seo" })).toHaveTextContent(
+      "DS",
+    );
+  });
+
+  test("공백뿐인 name은 이니셜을 만들지 못해 대체 아이콘을 보여줌", () => {
+    const { container } = render(<Avatar name="   " />);
+
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    expect(getFallbackIcon(container)).toBeInTheDocument();
+  });
+});
+
+describe("Avatar 대체 아이콘", () => {
+  test("src와 name이 모두 없으면 아이콘으로 대체함", () => {
+    const { container } = render(<Avatar data-testid="avatar" />);
+
+    expect(getFallbackIcon(container)).toBeInTheDocument();
+  });
+});
+
+describe("Avatar 접근성", () => {
+  test("이미지에 이름이 있어도 이름이 한 번만 읽힘", () => {
+    const { container } = render(
+      <Avatar src="/dale.png" name="서달레" data-testid="avatar" />,
+    );
+
+    // 안쪽 <img>가 alt를 또 들고 있으면 같은 이름이 두 번 읽힙니다.
+    expect(getImage(container)).toHaveAttribute("alt", "");
+    expect(screen.getAllByRole("img")).toHaveLength(1);
+    expect(screen.getByTestId("avatar")).toHaveAccessibleName("서달레");
+  });
+
+  test("이니셜은 축약된 글자가 아니라 전체 이름으로 읽힘", () => {
+    render(<Avatar name="Dale Seo" />);
+
+    const avatar = screen.getByRole("img");
+    expect(avatar).toHaveAccessibleName("Dale Seo");
+    expect(avatar).toHaveTextContent("DS");
+    expect(screen.queryByRole("img", { name: "DS" })).not.toBeInTheDocument();
+  });
+
+  test("이름이 없는 대체 아이콘은 접근성 트리에 아무것도 노출하지 않음", () => {
+    render(<Avatar data-testid="avatar" />);
+
+    // 아이콘 자체가 이미 가려져 있어 루트를 aria-hidden으로 덮지 않아도 읽히지 않습니다.
+    // 루트를 덮으면 소비자가 이름을 붙일 수 없고, 포커스가 생기면 ARIA 위반이 됩니다.
+    expect(screen.getByTestId("avatar")).not.toHaveAttribute("aria-hidden");
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    expect(screen.queryByRole("presentation")).not.toBeInTheDocument();
+  });
+
+  test("대체 아이콘에 aria-label을 주면 그 이름으로 읽힘", () => {
+    render(<Avatar aria-label="알 수 없는 사용자" />);
+
+    expect(screen.getByRole("img")).toHaveAccessibleName("알 수 없는 사용자");
+  });
+
+  test("이름은 표시 형태와 상관없이 항상 바깥 span이 전달함", () => {
+    render(<Avatar name="서달레" data-testid="initial" />);
+    render(<Avatar src="/dale.png" name="서달레" data-testid="image" />);
+
+    for (const id of ["initial", "image"]) {
+      const outer = screen.getByTestId(id);
+      expect(outer).toHaveAttribute("role", "img");
+      expect(outer).toHaveAccessibleName("서달레");
+    }
+  });
+
+  test("이름이 없으면 역할도 붙이지 않아 이름 없는 이미지가 되지 않음", () => {
+    render(<Avatar data-testid="avatar" />);
+
+    // role="img"만 남으면 스크린 리더가 이름 없는 이미지로 읽습니다.
+    expect(screen.getByTestId("avatar")).not.toHaveAttribute("role");
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  test("공백뿐인 name은 이름으로 쓰지 않음", () => {
+    render(<Avatar name="   " data-testid="avatar" />);
+
+    expect(screen.getByTestId("avatar")).not.toHaveAttribute("role");
+    expect(screen.getByTestId("avatar")).not.toHaveAttribute("aria-label");
+  });
+
+  test("소비자가 레이블을 주면 바깥 span이 그 이름을 가짐", () => {
+    render(
+      <Avatar
+        src="/dale.png"
+        name="서달레"
+        aria-label="작성자 서달레"
+        data-testid="avatar"
+      />,
+    );
+
+    // 바깥에 role="img"가 붙으면 ARIA 규칙상 자식은 보조기기에서 무시되지만,
+    // Testing Library의 역할 질의는 그 규칙을 흉내내지 않으므로 여기서는
+    // 이름이 바깥에 실렸다는 것까지만 확인합니다.
+    expect(screen.getByTestId("avatar")).toHaveAccessibleName("작성자 서달레");
+  });
+});
+
+describe("Avatar className", () => {
+  test.each(["image", "initial", "fallback"] as const)(
+    "%s 표시에서 전달한 className이 기본 스타일과 함께 적용됨",
+    (variant) => {
+      const props = {
+        image: { src: "/dale.png" },
+        initial: { name: "서달레" },
+        fallback: {},
+      }[variant];
+
+      render(<Avatar {...props} className="my-class" data-testid="avatar" />);
+
+      const avatar = screen.getByTestId("avatar");
+      expect(avatar).toHaveClass("my-class");
+      expect(avatar).toHaveClass("bdr_full");
+      expect(avatar).toHaveClass("w_10");
+    },
+  );
+});
+
+describe("Avatar 크기", () => {
+  test.each([
+    ["sm", "w_8", "h_8"],
+    ["md", "w_10", "h_10"],
+    ["lg", "w_12", "h_12"],
+  ] as const)("%s는 %s/%s 크기로 렌더링됨", (size, widthClass, heightClass) => {
+    render(<Avatar name="서달레" size={size} data-testid="avatar" />);
+
+    const avatar = screen.getByTestId("avatar");
+    expect(avatar).toHaveClass(widthClass);
+    expect(avatar).toHaveClass(heightClass);
+  });
+
+  test("기본 크기는 md", () => {
+    render(<Avatar name="서달레" data-testid="avatar" />);
+
+    expect(screen.getByTestId("avatar")).toHaveClass("w_10");
+  });
+});
+
+describe("getInitial", () => {
+  test.each([
+    ["서달레", "서"],
+    ["서", "서"],
+    ["서 달레", "서"],
+    ["山田太郎", "山"],
+    ["﨑田", "﨑"],
+    ["𠀋田", "𠀋"],
+    ["ﾀﾅｶ", "ﾀ"],
+    ["さくら", "さ"],
+    ["Dale Seo", "DS"],
+    ["dale seo", "DS"],
+    ["Dale  Seo", "DS"],
+    ["  Dale Seo  ", "DS"],
+    ["Dale Seo Kim", "DS"],
+    ["dale", "DA"],
+    ["D", "D"],
+    ["", ""],
+    ["   ", ""],
+  ])('"%s"의 이니셜은 "%s"', (name, expected) => {
+    expect(getInitial(name)).toBe(expected);
+  });
+});

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,0 +1,139 @@
+import { type HTMLAttributes, type Ref, useState } from "react";
+import { css, cva, cx } from "../../../styled-system/css";
+import { Icon } from "../Icon/Icon";
+import { getInitial } from "./getInitial";
+
+/** 아바타의 크기 */
+export type AvatarSize = "sm" | "md" | "lg";
+
+export interface AvatarProps extends Omit<
+  HTMLAttributes<HTMLSpanElement>,
+  "style" | "children"
+> {
+  /** 이미지 주소. 비어 있거나 불러오기에 실패하면 이니셜 → 대체 아이콘 순으로 표시됩니다. */
+  src?: string;
+  /** 사용자 이름. 이니셜을 만드는 데 쓰이고 이미지의 대체 텍스트가 됩니다. */
+  name?: string;
+  /** 크기. `sm`은 32px, `md`는 40px, `lg`는 48px입니다. */
+  size?: AvatarSize;
+  /** 요소 참조 */
+  ref?: Ref<HTMLSpanElement>;
+}
+
+/** 표시 형태 */
+type AvatarVariant = "image" | "initial" | "fallback";
+
+/** 쓸 수 있는 값에 따라 이미지 → 이니셜 → 대체 아이콘 순으로 표시 형태를 고릅니다. */
+function getVariant(canShowImage: boolean, initial: string): AvatarVariant {
+  if (canShowImage) {
+    return "image";
+  }
+
+  if (initial) {
+    return "initial";
+  }
+
+  return "fallback";
+}
+
+/**
+ * 아바타(Avatar)는 현재 로그인한 사용자나 콘텐츠 작성자의 프로필 이미지를 동그라미나 네모 형태로 시각화하고(사용자 식별 기능), 이미지가 없을 때는 이름의 이니셜이나 기본 아이콘을 대신 보여주어(대체 정보 제공) 서비스 내에서 사용자의 고유한 정체성과 소속감을 직관적으로 표현해 주는 기본 컴포넌트입니다.
+ *
+ * `src`가 있으면 이미지를, 없거나 불러오기에 실패하면 `name`으로 만든 이니셜을, 둘 다 없으면 대체 아이콘을 표시합니다.
+ *
+ * ### 이니셜 규칙
+ * 한 글자만으로 구분되는 한글·한자·가나는 첫 글자만, 영문은 두 글자를 사용합니다.
+ *
+ * - `"서달레"` → `"서"`
+ * - `"Dale Seo"` → `"DS"` (공백으로 나뉘면 각 단어의 첫 글자)
+ * - `"dale"` → `"DA"` (한 단어면 앞 두 글자)
+ *
+ * ### 접근성(Accessibility) 안내
+ * - `name`이 있으면 이미지의 대체 텍스트로 쓰입니다.
+ * - `name`이 없으면 읽을 이름이 없어 아무것도 읽히지 않습니다.
+ * - 이름이 필요한 자리(아바타만 있는 버튼, 아바타 묶음 등)에는 `aria-label`이나
+ *   `aria-labelledby`를 직접 넘기면 그 이름으로 읽힙니다.
+ */
+export function Avatar({
+  ref,
+  src,
+  name,
+  size = "md",
+  className,
+  ...rest
+}: AvatarProps) {
+  const [failedSrc, setFailedSrc] = useState<string>();
+  const initial = name ? getInitial(name) : "";
+  const canShowImage = !!src && src !== failedSrc;
+  const variant = getVariant(canShowImage, initial);
+  const label = name?.trim() || undefined;
+  const hasAccessibleName =
+    label !== undefined ||
+    rest["aria-label"] !== undefined ||
+    rest["aria-labelledby"] !== undefined;
+
+  return (
+    <span
+      ref={ref}
+      role={hasAccessibleName ? "img" : undefined}
+      aria-label={label}
+      className={cx(styles({ size, variant }), className)}
+      {...rest}
+    >
+      {variant === "image" && (
+        <img
+          src={src}
+          alt=""
+          className={imageStyles}
+          onError={() => setFailedSrc(src)}
+        />
+      )}
+      {variant === "initial" && <span>{initial}</span>}
+      {variant === "fallback" && <Icon name="user" size={size} />}
+    </span>
+  );
+}
+
+const styles = cva({
+  base: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+    borderRadius: "full",
+    border: "brand",
+    overflow: "hidden",
+    userSelect: "none",
+  },
+  variants: {
+    size: {
+      sm: { width: "8", height: "8" },
+      md: { width: "10", height: "10" },
+      lg: { width: "12", height: "12" },
+    },
+    variant: {
+      image: {},
+      initial: {
+        borderColor: "transparent",
+        bg: "bgSolid.brand",
+        color: "fgSolid.brand",
+      },
+      fallback: {
+        borderColor: "transparent",
+        bg: "bg.neutral.hover",
+        color: "fg.neutral",
+      },
+    },
+  },
+  compoundVariants: [
+    { size: "sm", variant: "initial", css: { textStyle: "label.sm" } },
+    { size: "md", variant: "initial", css: { textStyle: "label.md" } },
+    { size: "lg", variant: "initial", css: { textStyle: "label.lg" } },
+  ],
+});
+
+const imageStyles = css({
+  width: "100%",
+  height: "100%",
+  objectFit: "cover",
+});

--- a/src/components/Avatar/getInitial.ts
+++ b/src/components/Avatar/getInitial.ts
@@ -1,0 +1,38 @@
+/**
+ * 한 글자만으로 충분히 구분되는 문자.
+ * 한글, 한자(호환 한자·확장 영역 포함), 히라가나·가타카나를 포함합니다.
+ */
+const CJK_CHARACTER =
+  /[\p{Script=Hangul}\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u;
+
+/**
+ * 이름에서 이니셜을 만듭니다.
+ *
+ * 한글처럼 한 글자에 뜻이 담기는 문자는 첫 글자만, 영문처럼 한 글자로는 구분이 어려운
+ * 문자는 두 글자를 사용합니다.
+ *
+ * - `"서달레"` → `"서"`
+ * - `"Dale Seo"` → `"DS"`
+ * - `"dale"` → `"DA"`
+ */
+export function getInitial(name: string): string {
+  const trimmed = name.trim();
+
+  if (!trimmed) {
+    return "";
+  }
+
+  const characters = Array.from(trimmed);
+
+  if (CJK_CHARACTER.test(characters[0])) {
+    return characters[0];
+  }
+
+  const words = trimmed.split(/\s+/);
+
+  if (words.length > 1) {
+    return (Array.from(words[0])[0] + Array.from(words[1])[0]).toUpperCase();
+  }
+
+  return characters.slice(0, 2).join("").toUpperCase();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,11 @@
 import "./index.css";
 
 export type { FieldProps } from "./components/shared/types";
+export {
+  Avatar,
+  type AvatarProps,
+  type AvatarSize,
+} from "./components/Avatar/Avatar";
 export { Box, type BoxProps } from "./components/Box/Box";
 export { Button, type ButtonProps } from "./components/Button/Button";
 export {


### PR DESCRIPTION
Avatar 컴포넌트를 추가합니다. `src`와 `name` 유무에 따라 이미지 → 이니셜 → 기본 아이콘 순으로 표시하며, 형태를 지정하는 prop은 없습니다.

- 크기: `sm` 32px · `md` 40px(기본) · `lg` 48px
- 이니셜: 한글·한자·가나는 첫 글자, 영문은 두 글자 (`"서달레"` → `"서"`, `"Dale Seo"` → `"DS"`)
- 이니셜 API는 #1095 협의 항목으로, `initial`을 직접 받지 않고 `name`에서 만들도록 했습니다.

## 테스팅

- 유닛 테스트 41개 추가, 전체 684개 통과 / `tsc`·`eslint`·`prettier` 통과
- Storybook에서 세 형태 × 세 크기를 [Figma 시트](https://www.figma.com/design/mQ2ETYC6LXGOwVETov3CgO/DaleUI-Kit?node-id=9560-215)와 대조
- 대비(WCAG AA) 라이트·다크 모두 확인

## 체크 리스트

- [x] 코드 리뷰를 요청하기 전에 반드시 CI가 통과하는지 확인해주세요.
- [x] 컴포넌트나 스토리 변경이 있는 경우 PR에 ui 태그를 달아주세요.
  - [x] UI Tests를 통해 스냅샷 차이가 의도된 것인지 확인해주세요.
  - [x] UI Review를 통해 디자이너에게 리뷰를 요청하고 승인을 받으세요.
